### PR TITLE
Add configurable mutation profiles, path exclusions, and per-mutant reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Common adjustments:
 - Enable/disable mutation categories: status code, headers, and JSON body.
 - Enable/disable individual operators, such as `operator.sc.replaceWith40x.enabled=false`.
 - Tune numeric and string ranges used by value-level operators (e.g., min/max length, min/max numeric values).
+- Ignore selected JSON body paths with `mutation.body.ignore.paths=Body/id,/user/token`.
 
 Ready-to-use template configurations are provided in `httpmutator-core/src/main/resources`:
 - `rest-mutation.properties`: all currently supported operators enabled.

--- a/README.md
+++ b/README.md
@@ -102,20 +102,39 @@ filter.runAllMutations();
 For setup details and report outputs, see [docs/restassured-integration.md](docs/restassured-integration.md).
 
 ## Configuration
-HttpMutator is configurable: you can enable/disable mutation categories and tune value ranges used by certain operators.
-Defaults are loaded from `httpmutator-core/src/main/resources/json-mutation.properties` via `PropertyManager`.
+HttpMutator is configurable: you can enable or disable mutation categories and individual operators, and tune value ranges used by certain operators.
+Defaults are loaded from `httpmutator-core/src/main/resources/http-mutation.properties` via `PropertyManager`.
 
 Common adjustments:
 - Enable/disable mutation categories: status code, headers, and JSON body.
+- Enable/disable individual operators, such as `operator.sc.replaceWith40x.enabled=false`.
 - Tune numeric and string ranges used by value-level operators (e.g., min/max length, min/max numeric values).
-- Enable/disable specific header-related mutations (e.g., media type, charset).
+
+Ready-to-use template configurations are provided in `httpmutator-core/src/main/resources`:
+- `rest-mutation.properties`: all currently supported operators enabled.
+- `graphql-mutation.properties`: status-code operators disabled while header and JSON payload operators remain enabled.
+
+Pass any properties file through the Java API or CLI. The file is loaded as an override on top of the default `http-mutation.properties`, so custom files may contain only changed keys. Seed and mutation strategy remain separate runtime settings configured through the Java API or CLI.
 
 Programmatic override:
 ```java
 import es.us.isa.httpmutator.core.util.PropertyManager;
 
 PropertyManager.setProperty("operator.body.enabled", "true");
+PropertyManager.setProperty("operator.sc.replaceWith40x.enabled", "false");
 PropertyManager.setProperty("operator.value.string.length.max", "256");
+```
+
+File-based override:
+```java
+import es.us.isa.httpmutator.core.HttpMutator;
+
+HttpMutator mutator = new HttpMutator(java.nio.file.Paths.get("graphql-mutation.properties"));
+```
+
+CLI override:
+```bash
+java -jar httpmutator.jar -i traffic.jsonl --properties graphql-mutation.properties
 ```
 Reset to defaults:
 
@@ -124,6 +143,8 @@ import es.us.isa.httpmutator.core.util.PropertyManager;
 
 PropertyManager.resetProperties();
 ```
+
+See [docs/operator-configuration.md](docs/operator-configuration.md) for the complete operator-to-property mapping and example configurations.
 
 ## Extending HttpMutator
 HttpMutator is designed for extension: add new operators, customize mutation strategies, and plug in reporters or writers for your own outputs. The core API exposes extension points in `AbstractOperator`, `AbstractMutator`, `MutationStrategy`, `MutantWriter`, and `MutantReporter`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,6 +51,14 @@ The CLI uses the operator selection and mutation ranges from `httpmutator-core/s
 
 REST and GraphQL template configurations are available as `rest-mutation.properties` and `graphql-mutation.properties` in the core resources. These files control operator applicability only; `--seed` and `--strategy` remain independent CLI options.
 
+To skip body fields during mutation, put a comma-separated list in a properties file and pass it with `--properties`:
+
+```properties
+mutation.body.ignore.paths=Body/id, /user/token, items/0/id
+```
+
+Paths are subtree matches. For example, `Body/user` skips `Body/user` and `Body/user/...` body mutants while status-code and header mutants remain enabled.
+
 See [operator-configuration.md](operator-configuration.md) for the full list of operator switches.
 
 ## Examples

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ There are no subcommands; all flags are passed to the main entry point.
 - `-o, --output <dir>` (optional, default: `hm-output`) Output directory.
 - `-s, --strategy <name>` (optional, default: `random`) Mutation strategy. Supported values: `random`, `exhaustive`, or `all` (alias for `exhaustive`).
 - `--seed <long>` (optional, default: `42`) Random seed for the mutation strategy.
+- `--properties <file>` (optional) Properties override file. Missing keys are read from the default configuration.
 - `--includeMeta` (optional, flag) Include mutation metadata fields in JSONL output.
 - `--writeJsonl` (optional, flag) Write JSONL output. If no output flags are provided, JSONL output is enabled by default.
 - `--writeHar` (optional, flag) Write HAR output.
@@ -46,7 +47,11 @@ If you pass both `--writeJsonl` and `--writeHar`, the CLI writes both outputs.
 
 ## Configuration
 
-The CLI uses the library defaults from `httpmutator-core/src/main/resources/json-mutation.properties`. There are no CLI flags for overriding those properties in the current implementation.
+The CLI uses the operator selection and mutation ranges from `httpmutator-core/src/main/resources/http-mutation.properties` by default. Pass `--properties <file>` to overlay a custom properties file on top of those defaults.
+
+REST and GraphQL template configurations are available as `rest-mutation.properties` and `graphql-mutation.properties` in the core resources. These files control operator applicability only; `--seed` and `--strategy` remain independent CLI options.
+
+See [operator-configuration.md](operator-configuration.md) for the full list of operator switches.
 
 ## Examples
 
@@ -78,4 +83,13 @@ java -jar httpmutator-core/target/httpmutator.jar \
   --writeJsonl \
   --writeHar \
   --reporter csv
+```
+
+Use a custom properties file:
+
+```bash
+java -jar httpmutator-core/target/httpmutator.jar \
+  -i httpmutator-core/src/test/resources/httpmutatorInput.jsonl \
+  -o hm-output \
+  --properties graphql-mutation.properties
 ```

--- a/docs/extending-httpmutator.md
+++ b/docs/extending-httpmutator.md
@@ -106,13 +106,27 @@ Integrations can implement `BidirectionalConverter<T>` to map client responses t
 
 ## Configuration overrides
 
-Mutation toggles live in `json-mutation.properties`. You can override them programmatically:
+Mutation toggles live in `http-mutation.properties`. Category and individual operator settings can be overridden programmatically:
 
 ```java
 import es.us.isa.httpmutator.core.util.PropertyManager;
 
 PropertyManager.setProperty("operator.body.enabled", "true");
+PropertyManager.setProperty("operator.value.string.boundary.enabled", "false");
 PropertyManager.setProperty("operator.value.string.length.max", "256");
 ```
 
 Call `PropertyManager.resetProperties()` to restore defaults.
+
+For file-based overrides, pass any properties file to `PropertyManager.loadProperties(path)` or construct `HttpMutator` with that path. The file is overlaid on the defaults, so it may contain only changed keys.
+
+When registering a built-in-style operator from an `AbstractMutator` subclass, use `addOperatorIfEnabled(...)` so the operator follows the same configuration rules:
+
+```java
+addOperatorIfEnabled(
+        "operator.value.string.example.enabled",
+        "example",
+        ExampleOperator::new);
+```
+
+Missing operator switches default to enabled for backward compatibility. Explicit values must be `true` or `false`.

--- a/docs/mutation-operators.md
+++ b/docs/mutation-operators.md
@@ -84,6 +84,8 @@ This document explains how each mutation operator is applied, what it can act on
 - **Operator**: classes that extend `AbstractOperator` and implement `doMutate(...)`. These live under `.../operator/` packages.
 - **Flow**: a mutator scans one recorded HTTP response (status, headers, JSON body) and picks the applicable operator(s) for each target part; each operator performs one small change to produce a mutant variant, which is then collected and exported as JSONL (optionally .jsonl.zst shards), HAR, or kept in memory.
 
+Each operator can be enabled or disabled independently through `http-mutation.properties`. See [Operator Configuration](operator-configuration.md) for the property corresponding to each operator and for the REST and GraphQL example configurations.
+
 ## Status Code Mutation Operators
 ### R2XX - Replacement with status code 2XX
 Replaces the status code with a 2XX success code to simulate incorrectly successful responses (code uses `{200, 201, 202, 204}` and does not include 202).
@@ -572,7 +574,7 @@ public class ExampleOperator extends AbstractOperator {
 ## Step 2. Register the operator in a mutator
 
 Mutators select mutation targets and apply mutation operators using an operator map.
-An operator becomes available to a mutator after it is inserted into that map via `getOperators().put(...)`.
+An operator becomes available to a mutator after it is conditionally registered through `addOperatorIfEnabled(...)`.
 Registration is typically performed by extending an existing mutator such as StringMutator.
 
 Minimal mutator integration example:
@@ -583,7 +585,10 @@ import es.us.isa.httpmutator.core.util.OperatorNames;
 public class CustomStringMutator extends StringMutator {
     public CustomStringMutator() {
         super();
-        getOperators().put(OperatorNames.REPLACE, new ExampleOperator());
+        addOperatorIfEnabled(
+                "operator.value.string.example.enabled",
+                "example",
+                ExampleOperator::new);
     }
 }
 ```

--- a/docs/operator-configuration.md
+++ b/docs/operator-configuration.md
@@ -7,6 +7,23 @@ Random seed and mutation strategy are intentionally separate from this file:
 - Java API: `new HttpMutator(seed)` and `withMutationStrategy(...)`
 - CLI: `--seed` and `--strategy random|exhaustive`
 
+## Ignoring Body Paths
+
+Use `mutation.body.ignore.paths` to prevent path-based JSON body mutation for selected fields:
+
+```properties
+mutation.body.ignore.paths=Body/id, /user/token, items/0/id
+```
+
+Paths are normalized to the existing mutation metadata style (`Body/...`). For example, `Body/user`, `/user`, and `user` all refer to `Body/user`. Matching is subtree-based: ignoring `Body/user` skips mutants for `Body/user` and all descendants such as `Body/user/id`. Ignoring `Body` disables body mutants only; status-code and header mutants still run.
+
+The same behavior is also available through the Java API:
+
+```java
+HttpMutator mutator = new HttpMutator()
+        .withIgnoredBodyPaths(java.util.Arrays.asList("Body/id", "/user/token"));
+```
+
 ## Operator switches
 
 | Paper operator | Implementation scope | Enabled property |

--- a/docs/operator-configuration.md
+++ b/docs/operator-configuration.md
@@ -1,0 +1,55 @@
+# Operator Configuration
+
+HttpMutator loads its default mutation settings from `http-mutation.properties`. Category switches such as `operator.sc.enabled` can disable an entire response component, while the switches below control individual operators. A custom properties file can be passed through the Java API or CLI and is loaded as an override on top of the default file. A missing individual operator switch defaults to enabled for backward compatibility. Explicit values must be `true` or `false`.
+
+Random seed and mutation strategy are intentionally separate from this file:
+
+- Java API: `new HttpMutator(seed)` and `withMutationStrategy(...)`
+- CLI: `--seed` and `--strategy random|exhaustive`
+
+## Operator switches
+
+| Paper operator | Implementation scope | Enabled property |
+| --- | --- | --- |
+| R2XX | Status replacement with 2XX | `operator.sc.replaceWith20x.enabled` |
+| R4XX | Status replacement with 4XX | `operator.sc.replaceWith40x.enabled` |
+| R5XX | Status replacement with 5XX | `operator.sc.replaceWith50x.enabled` |
+| CTC | Content-Type media type replacement | `operator.header.mediaType.replace.enabled` |
+| CTD | Content-Type media type deletion | `operator.header.mediaType.null.enabled` |
+| CPC | Charset replacement | `operator.header.charset.replace.enabled` |
+| CPD | Charset deletion | `operator.header.charset.null.enabled` |
+| LHC | Location header change | `operator.header.location.mutate.enabled` |
+| LHD | Location header deletion | `operator.header.location.null.enabled` |
+| AEA | Array element addition | `operator.array.addElement.enabled` |
+| AER | Array element removal | `operator.array.removeElement.enabled` |
+| AEE | Array element exchange | `operator.array.disorderElements.enabled` |
+| EAS | Empty array setting | `operator.array.empty.enabled` |
+| OPA | Object property addition | `operator.object.addElement.enabled` |
+| OPR | Object property removal | `operator.object.removeElement.enabled` |
+| OTPR | Object-type property removal | `operator.object.removeObjectElement.enabled` |
+| PTC | Property type change | `operator.value.long.changeType.enabled`, `operator.value.double.changeType.enabled`, `operator.value.string.changeType.enabled`, `operator.value.boolean.changeType.enabled`, `operator.value.null.changeType.enabled`, `operator.object.changeType.enabled`, `operator.array.changeType.enabled` |
+| BPR | Boolean property reverse | `operator.value.boolean.mutate.enabled` |
+| NPS | Null property setting | `operator.value.long.null.enabled`, `operator.value.double.null.enabled`, `operator.value.string.null.enabled`, `operator.value.boolean.null.enabled`, `operator.object.null.enabled`, `operator.array.null.enabled` |
+| NPR | Numeric property replacement | `operator.value.long.replace.enabled`, `operator.value.double.replace.enabled` |
+| SPR | String property replacement | `operator.value.string.replace.enabled` |
+| SCA | Special characters addition | `operator.value.string.addSpecialCharacters.enabled` |
+| SRE | String length reduction/extension | `operator.value.string.boundary.enabled` |
+
+## Example Configurations
+
+Two complete configurations are included:
+
+- `rest-mutation.properties` enables every currently supported operator.
+- `graphql-mutation.properties` disables R2XX, R4XX, and R5XX because GraphQL application errors commonly retain HTTP status 200. All header and JSON payload operators remain enabled.
+
+To use one, pass the file path through the Java API or CLI:
+
+```java
+HttpMutator mutator = new HttpMutator(java.nio.file.Paths.get("graphql-mutation.properties"));
+```
+
+```bash
+java -jar httpmutator.jar -i traffic.jsonl --properties graphql-mutation.properties
+```
+
+The GraphQL configuration deliberately keeps `operator.sc.enabled=true` and disables the three status operators individually. This demonstrates the operator-selection mechanism while producing no status-code mutants.

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/AbstractMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/AbstractMutator.java
@@ -6,12 +6,15 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import es.us.isa.httpmutator.core.util.RandomUtils;
+
+import static es.us.isa.httpmutator.core.util.PropertyManager.readProperty;
 
 /**
  * Superclass for mutators. A mutator decides on the type of mutation to be
@@ -45,6 +48,28 @@ public abstract class AbstractMutator {
 
     public void setOperators(LinkedHashMap<String, AbstractOperator> operators) {
         this.operators = operators;
+    }
+
+    protected void addOperatorIfEnabled(
+            String enabledProperty,
+            String operatorName,
+            Supplier<AbstractOperator> operatorSupplier) {
+        String configuredValue = readProperty(enabledProperty);
+        boolean enabled = true;
+        if (configuredValue != null) {
+            String normalizedValue = configuredValue.trim();
+            if ("true".equalsIgnoreCase(normalizedValue)) {
+                enabled = true;
+            } else if ("false".equalsIgnoreCase(normalizedValue)) {
+                enabled = false;
+            } else {
+                throw new IllegalArgumentException(
+                        "Property " + enabledProperty + " must be true or false, but was: " + configuredValue);
+            }
+        }
+        if (enabled) {
+            operators.put(operatorName, operatorSupplier.get());
+        }
     }
 
     protected boolean shouldApplyMutation() {

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutator.java
@@ -8,12 +8,14 @@ import es.us.isa.httpmutator.core.model.StandardHttpResponse;
 import es.us.isa.httpmutator.core.reader.HttpExchangeReader;
 import es.us.isa.httpmutator.core.reporter.MutantReporter;
 import es.us.isa.httpmutator.core.strategy.MutationStrategy;
+import es.us.isa.httpmutator.core.util.PropertyManager;
 import es.us.isa.httpmutator.core.util.RandomUtils;
 import es.us.isa.httpmutator.core.writer.MutantWriter;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,6 +57,17 @@ public class HttpMutator implements AutoCloseable {
     }
 
     public HttpMutator(long randomSeed) {
+        this.randomSeed = randomSeed;
+        RandomUtils.setSeed(randomSeed);
+        this.engine = new HttpMutatorEngine();
+    }
+
+    public HttpMutator(Path propertiesFile) {
+        this(42L, propertiesFile);
+    }
+
+    public HttpMutator(long randomSeed, Path propertiesFile) {
+        PropertyManager.loadProperties(propertiesFile);
         this.randomSeed = randomSeed;
         RandomUtils.setSeed(randomSeed);
         this.engine = new HttpMutatorEngine();

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutator.java
@@ -17,6 +17,7 @@ import java.io.Reader;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -112,6 +113,22 @@ public class HttpMutator implements AutoCloseable {
         this.randomSeed = randomSeed;
         RandomUtils.setSeed(randomSeed);
         return this;
+    }
+
+    public HttpMutator withIgnoredBodyPaths(Collection<String> paths) {
+        engine.setIgnoredBodyPaths(paths);
+        return this;
+    }
+
+    public HttpMutator addIgnoredBodyPath(String path) {
+        List<String> paths = new ArrayList<>(engine.getIgnoredBodyPaths());
+        paths.add(path);
+        engine.setIgnoredBodyPaths(paths);
+        return this;
+    }
+
+    public List<String> getIgnoredBodyPaths() {
+        return engine.getIgnoredBodyPaths();
     }
 
     public long getRandomSeed() {

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutator.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -129,6 +130,14 @@ public class HttpMutator implements AutoCloseable {
      * - invoke extraHandler (per context)
      */
     private void processExchange(HttpExchange exchange, Consumer<StandardHttpResponse> perMutantConsumer) {
+        processExchangeWithMetadata(exchange, perMutantConsumer == null ? null : (mutated, mutant) -> perMutantConsumer.accept(mutated));
+    }
+
+    /**
+     * Core pipeline variant that exposes both the mutated response and the
+     * Mutant metadata to integration layers that need per-mutant reporting.
+     */
+    private void processExchangeWithMetadata(HttpExchange exchange, BiConsumer<StandardHttpResponse, Mutant> perMutantConsumer) {
 
         Objects.requireNonNull(exchange, "exchange must not be null");
         ensureStrategyConfigured();
@@ -156,7 +165,7 @@ public class HttpMutator implements AutoCloseable {
                     }
 
                     if (perMutantConsumer != null) {
-                        perMutantConsumer.accept(mutated);
+                        perMutantConsumer.accept(mutated, mutant);
                     }
                 }
             });
@@ -275,6 +284,22 @@ public class HttpMutator implements AutoCloseable {
     }
 
     public void mutate(StandardHttpResponse original, Consumer<StandardHttpResponse> consumer) {
+        mutate(original, "", consumer);
+    }
+
+    public void mutate(StandardHttpResponse original, String label, BiConsumer<StandardHttpResponse, Mutant> consumer) {
+
+        Objects.requireNonNull(original, "original must not be null");
+        Objects.requireNonNull(consumer, "consumer must not be null");
+        ensureStrategyConfigured();
+
+        String id = label == null || label.isEmpty() ? "in-memory" : label;
+        HttpExchange exchange = new HttpExchange(null, original, id);
+
+        processExchangeWithMetadata(exchange, consumer);
+    }
+
+    public void mutate(StandardHttpResponse original, BiConsumer<StandardHttpResponse, Mutant> consumer) {
         mutate(original, "", consumer);
     }
 

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutatorCli.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutatorCli.java
@@ -82,10 +82,12 @@ public final class HttpMutatorCli {
         MutationStrategy strategy = createStrategy(config);
 
         try (Reader in = Files.newBufferedReader(input, StandardCharsets.UTF_8);
-             HttpMutator mutator = new HttpMutator(config.randomSeed)
-                     .withMutationStrategy(strategy)
-                     .withWriters(writers)
-                     .withReporters(reporters)) {
+             HttpMutator mutator = (config.propertiesFile == null
+                     ? new HttpMutator(config.randomSeed)
+                     : new HttpMutator(config.randomSeed, config.propertiesFile))
+	                     .withMutationStrategy(strategy)
+	                     .withWriters(writers)
+	                     .withReporters(reporters)) {
 
             mutator.mutateStream(exchangeReader, in);
         }
@@ -207,6 +209,7 @@ public final class HttpMutatorCli {
         final String baseName;
         final boolean includeMeta;
         final long randomSeed;
+        final Path propertiesFile;
         final List<String> reporterNames;
 
         final StrategyName strategy;
@@ -221,6 +224,7 @@ public final class HttpMutatorCli {
                           String baseName,
                           boolean includeMeta,
                           long randomSeed,
+                          Path propertiesFile,
                           List<String> reporterNames,
                           StrategyName strategy,
                           boolean writeHar,
@@ -231,6 +235,7 @@ public final class HttpMutatorCli {
             this.baseName = baseName;
             this.includeMeta = includeMeta;
             this.randomSeed = randomSeed;
+            this.propertiesFile = propertiesFile;
             this.reporterNames = reporterNames;
             this.strategy = strategy;
             this.writeHar = writeHar;
@@ -249,6 +254,7 @@ public final class HttpMutatorCli {
             List<String> reporterNames = new ArrayList<>();
             boolean includeMeta = false;
             long randomSeed = 42L;
+            Path propertiesFile = null;
             StrategyName strategy = StrategyName.RANDOM;
 
             // Output flags (default selection implemented in createWriters)
@@ -297,6 +303,16 @@ public final class HttpMutatorCli {
                             throw new IllegalArgumentException("--seed requires a long value");
                         }
                         randomSeed = Long.parseLong(args[++i]);
+                        break;
+
+                    case "--properties":
+                        if (i + 1 >= args.length) {
+                            throw new IllegalArgumentException("--properties requires a file path");
+                        }
+                        propertiesFile = Paths.get(args[++i]);
+                        if (!Files.isRegularFile(propertiesFile) || !Files.isReadable(propertiesFile)) {
+                            throw new IllegalArgumentException("--properties file is not readable: " + propertiesFile);
+                        }
                         break;
 
                     case "--strategy":
@@ -358,7 +374,7 @@ public final class HttpMutatorCli {
 
             return new CliConfig(
                     input, format, outputDir, baseName,
-                    includeMeta, randomSeed, reporterNames, strategy,
+                    includeMeta, randomSeed, propertiesFile, reporterNames, strategy,
                     writeHar, writeJsonl
             );
         }
@@ -398,6 +414,7 @@ public final class HttpMutatorCli {
         System.err.println("        Supported: exhaustive(all), random");
         System.err.println("      --includeMeta         Include mutation metadata fields in JSONL output");
         System.err.println("      --seed <long>         Random seed (default: 42)");
+        System.err.println("      --properties <file>   Properties override file");
         System.err.println("      --writeJsonl          Write JSONL output (default if no output flags are specified)");
         System.err.println("      --writeHar            Write HAR output");
         System.err.println("  -h, --help                Show this help and exit");

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutatorEngine.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/HttpMutatorEngine.java
@@ -4,6 +4,8 @@ import static es.us.isa.httpmutator.core.util.PropertyManager.readProperty;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -13,6 +15,7 @@ import es.us.isa.httpmutator.core.body.value.long0.LongMutator;
 import es.us.isa.httpmutator.core.body.value.null0.NullMutator;
 import es.us.isa.httpmutator.core.body.value.string0.StringMutator;
 import es.us.isa.httpmutator.core.util.JsonManager;
+import es.us.isa.httpmutator.core.util.BodyPathIgnoreMatcher;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -48,16 +51,33 @@ public class HttpMutatorEngine {
     private StringMutator stringMutator;
     private NullMutator nullMutator;
 
+    private List<String> ignoredBodyPaths;
+
     private final static double defaultPossibility = 1.0;
 
     public HttpMutatorEngine() {
+        ignoredBodyPaths = BodyPathIgnoreMatcher.parsePaths(readProperty("mutation.body.ignore.paths"));
         resetMutators();
+    }
+
+    void setIgnoredBodyPaths(Collection<String> ignoredBodyPaths) {
+        this.ignoredBodyPaths = BodyPathIgnoreMatcher.normalizePaths(ignoredBodyPaths);
+        if (bodyMutator != null) {
+            bodyMutator.setIgnoredBodyPaths(this.ignoredBodyPaths);
+        }
+    }
+
+    List<String> getIgnoredBodyPaths() {
+        return Collections.unmodifiableList(ignoredBodyPaths);
     }
 
     private void resetMutators() {
         statusCodeMutator = Boolean.parseBoolean(readProperty("operator.sc.enabled")) ? new StatusCodeMutator() : null;
         headerMutator = Boolean.parseBoolean(readProperty("operator.header.enabled")) ? new HeaderMutator() : null;
         bodyMutator = Boolean.parseBoolean(readProperty("operator.body.enabled")) ? new BodyMutator() : null;
+        if (bodyMutator != null) {
+            bodyMutator.setIgnoredBodyPaths(ignoredBodyPaths);
+        }
 
         booleanMutator = Boolean.parseBoolean(readProperty("operator.value.boolean.enabled")) ? new BooleanMutator() : null;
         doubleMutator = Boolean.parseBoolean(readProperty("operator.value.double.enabled")) ? new DoubleMutator() : null;

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/AbstractObjectOrArrayMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/AbstractObjectOrArrayMutator.java
@@ -138,6 +138,9 @@ public abstract class AbstractObjectOrArrayMutator extends AbstractMutator {
                 if (shouldApplyMutation()) {
                     // Mutate element by randomly choosing one mutation operator among 'operators' and applying the mutation:
                     String operator = getOperator();
+                    if (operator == null) {
+                        break;
+                    }
                     // If node is empty and an operator that will make no changes is selected
                     if (elementToMutate.size() == 0 && (operator.equals(REMOVE_ELEMENT)  || operator.equals(REMOVE_OBJECT_ELEMENT) || operator.equals(DISORDER_ELEMENTS) || operator.equals(EMPTY))) {
                         operators.remove(REMOVE_ELEMENT); // Discard all those operators
@@ -178,6 +181,9 @@ public abstract class AbstractObjectOrArrayMutator extends AbstractMutator {
             if (shouldApplyMutation()) {
                 // Mutate element by randomly choosing one mutation operator among 'operators' and applying the mutation:
                 String operator = getOperator();
+                if (operator == null) {
+                    break;
+                }
 
                 // If node is empty and an operator that will make no changes is selected
                 if (jsonNode.size() == 0 && (operator.equals(REMOVE_ELEMENT) || operator.equals(REMOVE_OBJECT_ELEMENT) || operator.equals(DISORDER_ELEMENTS) || operator.equals(EMPTY))) {

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/BodyMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/BodyMutator.java
@@ -747,7 +747,7 @@ public class BodyMutator {
     }
 
     /**
-     * @param propertyName  Name of the property in the json-mutation.properties
+     * @param propertyName  Name of the property in the http-mutation.properties
      *                      file, e.g., "operator.value.double.enabled"
      * @param propertyValue Value to set that property with
      */
@@ -757,7 +757,7 @@ public class BodyMutator {
     }
 
     /**
-     * Resets properties to the ones defined in json-mutation.properties
+     * Resets properties to the ones defined in http-mutation.properties
      */
     public void resetProperties() {
         PropertyManager.resetProperties();

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/BodyMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/BodyMutator.java
@@ -41,6 +41,7 @@ import es.us.isa.httpmutator.core.body.value.string0.StringMutator;
 import static es.us.isa.httpmutator.core.util.JsonManager.getNodeElement;
 import static es.us.isa.httpmutator.core.util.JsonManager.insertElement;
 import es.us.isa.httpmutator.core.util.OperatorNames;
+import es.us.isa.httpmutator.core.util.BodyPathIgnoreMatcher;
 import es.us.isa.httpmutator.core.util.PropertyManager;
 import static es.us.isa.httpmutator.core.util.PropertyManager.readProperty;
 import es.us.isa.httpmutator.core.util.RandomUtils;
@@ -74,11 +75,21 @@ public class BodyMutator {
     private NullMutator nullMutator;
     private ObjectMutator objectMutator;
     private ArrayMutator arrayMutator;
+    private List<String> ignoredBodyPaths;
 
     public BodyMutator() {
         objectMapper = new ObjectMapper();
+        ignoredBodyPaths = Collections.emptyList();
         resetJsonMutator();
         resetMutators();
+    }
+
+    public void setIgnoredBodyPaths(List<String> ignoredBodyPaths) {
+        this.ignoredBodyPaths = BodyPathIgnoreMatcher.normalizePaths(ignoredBodyPaths);
+    }
+
+    public List<String> getIgnoredBodyPaths() {
+        return ignoredBodyPaths;
     }
 
     // ========== Core method: streaming processing by path ==========
@@ -138,6 +149,9 @@ public class BodyMutator {
      */
     private void getAllMutants(JsonNode jsonNode, String parentPath, 
                                         double probability, Consumer<MutantGroup> consumer) {
+        if (BodyPathIgnoreMatcher.matches("Body" + parentPath, ignoredBodyPaths)) {
+            return;
+        }
         
         List<Mutant> currentPathMutants = new ArrayList<>();
         AbstractMutator mutator = getMutator(jsonNode);
@@ -181,6 +195,11 @@ public class BodyMutator {
                 Lists.newArrayList(jsonNode.fieldNames()).get(i) : null;
             Integer index = jsonNode.isArray() ? i : null;
             String currentPath = parentPath + "/" + (index == null ? propertyName : index);
+
+            if (BodyPathIgnoreMatcher.matches("Body" + currentPath, ignoredBodyPaths)) {
+                i++;
+                continue;
+            }
             
             // Generate mutations for current element and process immediately
             List<Mutant> elementMutants = generateMutantsForElement(

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/array/ArrayMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/array/ArrayMutator.java
@@ -25,12 +25,30 @@ public class ArrayMutator extends AbstractObjectOrArrayMutator {
 
     public void resetOperators() {
         operators.clear();
-        operators.put(OperatorNames.REMOVE_ELEMENT, new ArrayRemoveElementOperator());
-        operators.put(OperatorNames.EMPTY, new ArrayEmptyOperator());
-        operators.put(OperatorNames.ADD_ELEMENT, new ArrayAddElementOperator());
-        operators.put(OperatorNames.DISORDER_ELEMENTS, new ArrayDisorderElementsOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(ArrayNode.class));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(ArrayNode.class));
+        addOperatorIfEnabled(
+                "operator.array.removeElement.enabled",
+                OperatorNames.REMOVE_ELEMENT,
+                ArrayRemoveElementOperator::new);
+        addOperatorIfEnabled(
+                "operator.array.empty.enabled",
+                OperatorNames.EMPTY,
+                ArrayEmptyOperator::new);
+        addOperatorIfEnabled(
+                "operator.array.addElement.enabled",
+                OperatorNames.ADD_ELEMENT,
+                ArrayAddElementOperator::new);
+        addOperatorIfEnabled(
+                "operator.array.disorderElements.enabled",
+                OperatorNames.DISORDER_ELEMENTS,
+                ArrayDisorderElementsOperator::new);
+        addOperatorIfEnabled(
+                "operator.array.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(ArrayNode.class));
+        addOperatorIfEnabled(
+                "operator.array.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(ArrayNode.class));
     }
 
     public void resetFirstLevelOperators() {

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/object/ObjectMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/object/ObjectMutator.java
@@ -24,11 +24,26 @@ public class ObjectMutator extends AbstractObjectOrArrayMutator {
 
     public void resetOperators() {
         operators.clear();
-        operators.put(OperatorNames.REMOVE_ELEMENT, new ObjectRemoveElementOperator());
-        operators.put(OperatorNames.REMOVE_OBJECT_ELEMENT, new ObjectRemoveObjectTypeElementOperator());
-        operators.put(OperatorNames.ADD_ELEMENT, new ObjectAddElementOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(ObjectNode.class));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(ObjectNode.class));
+        addOperatorIfEnabled(
+                "operator.object.removeElement.enabled",
+                OperatorNames.REMOVE_ELEMENT,
+                ObjectRemoveElementOperator::new);
+        addOperatorIfEnabled(
+                "operator.object.removeObjectElement.enabled",
+                OperatorNames.REMOVE_OBJECT_ELEMENT,
+                ObjectRemoveObjectTypeElementOperator::new);
+        addOperatorIfEnabled(
+                "operator.object.addElement.enabled",
+                OperatorNames.ADD_ELEMENT,
+                ObjectAddElementOperator::new);
+        addOperatorIfEnabled(
+                "operator.object.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(ObjectNode.class));
+        addOperatorIfEnabled(
+                "operator.object.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(ObjectNode.class));
     }
 
     public void resetFirstLevelOperators() {

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/boolean0/BooleanMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/boolean0/BooleanMutator.java
@@ -18,8 +18,17 @@ public class BooleanMutator extends AbstractMutator {
     public BooleanMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.value.boolean.prob"));
-        operators.put(OperatorNames.MUTATE, new BooleanMutationOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(Boolean.class));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(Boolean.class));
+        addOperatorIfEnabled(
+                "operator.value.boolean.mutate.enabled",
+                OperatorNames.MUTATE,
+                BooleanMutationOperator::new);
+        addOperatorIfEnabled(
+                "operator.value.boolean.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(Boolean.class));
+        addOperatorIfEnabled(
+                "operator.value.boolean.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(Boolean.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/double0/DoubleMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/double0/DoubleMutator.java
@@ -3,7 +3,6 @@ package es.us.isa.httpmutator.core.body.value.double0;
 import es.us.isa.httpmutator.core.AbstractMutator;
 import es.us.isa.httpmutator.core.body.value.common.operator.ChangeTypeOperator;
 import es.us.isa.httpmutator.core.body.value.common.operator.NullOperator;
-import es.us.isa.httpmutator.core.body.value.double0.operator.DoubleMutationOperator;
 import es.us.isa.httpmutator.core.body.value.double0.operator.DoubleReplacementOperator;
 import es.us.isa.httpmutator.core.util.OperatorNames;
 import static es.us.isa.httpmutator.core.util.PropertyManager.readProperty;
@@ -18,10 +17,18 @@ public class DoubleMutator extends AbstractMutator {
 
     public DoubleMutator() {
         super();
-        prob = Float.parseFloat(readProperty("operator.value.string.prob"));
-        operators.put(OperatorNames.REPLACE, new DoubleReplacementOperator());
-        // operators.put(OperatorNames.MUTATE, new DoubleMutationOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(Double.class));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(Double.class));
+        prob = Float.parseFloat(readProperty("operator.value.double.prob"));
+        addOperatorIfEnabled(
+                "operator.value.double.replace.enabled",
+                OperatorNames.REPLACE,
+                DoubleReplacementOperator::new);
+        addOperatorIfEnabled(
+                "operator.value.double.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(Double.class));
+        addOperatorIfEnabled(
+                "operator.value.double.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(Double.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/long0/LongMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/long0/LongMutator.java
@@ -4,7 +4,6 @@ package es.us.isa.httpmutator.core.body.value.long0;
 import es.us.isa.httpmutator.core.AbstractMutator;
 import es.us.isa.httpmutator.core.body.value.common.operator.ChangeTypeOperator;
 import es.us.isa.httpmutator.core.body.value.common.operator.NullOperator;
-import es.us.isa.httpmutator.core.body.value.long0.operator.LongMutationOperator;
 import es.us.isa.httpmutator.core.body.value.long0.operator.LongReplacementOperator;
 import es.us.isa.httpmutator.core.util.OperatorNames;
 import static es.us.isa.httpmutator.core.util.PropertyManager.readProperty;
@@ -20,9 +19,17 @@ public class LongMutator extends AbstractMutator {
     public LongMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.value.long.prob"));
-        operators.put(OperatorNames.REPLACE, new LongReplacementOperator());
-        // operators.put(OperatorNames.MUTATE, new LongMutationOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(Long.class));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(Long.class));
+        addOperatorIfEnabled(
+                "operator.value.long.replace.enabled",
+                OperatorNames.REPLACE,
+                LongReplacementOperator::new);
+        addOperatorIfEnabled(
+                "operator.value.long.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(Long.class));
+        addOperatorIfEnabled(
+                "operator.value.long.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(Long.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/null0/NullMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/null0/NullMutator.java
@@ -18,6 +18,9 @@ public class NullMutator extends AbstractMutator {
     public NullMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.value.null.prob"));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(NullNode.class));
+        addOperatorIfEnabled(
+                "operator.value.null.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(NullNode.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/string0/StringMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/body/value/string0/StringMutator.java
@@ -5,7 +5,6 @@ import es.us.isa.httpmutator.core.body.value.common.operator.ChangeTypeOperator;
 import es.us.isa.httpmutator.core.body.value.common.operator.NullOperator;
 import es.us.isa.httpmutator.core.body.value.string0.operator.StringAddSpecialCharactersMutationOperator;
 import es.us.isa.httpmutator.core.body.value.string0.operator.StringBoundaryOperator;
-import es.us.isa.httpmutator.core.body.value.string0.operator.StringMutationOperator;
 import es.us.isa.httpmutator.core.body.value.string0.operator.StringReplacementOperator;
 import es.us.isa.httpmutator.core.util.OperatorNames;
 import static es.us.isa.httpmutator.core.util.PropertyManager.readProperty;
@@ -21,11 +20,25 @@ public class StringMutator extends AbstractMutator {
     public StringMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.value.string.prob"));
-        operators.put(OperatorNames.REPLACE, new StringReplacementOperator());
-        operators.put(OperatorNames.ADD_SPECIAL_CHARACTERS, new StringAddSpecialCharactersMutationOperator());
-//        operators.put(OperatorNames.MUTATE, new StringMutationOperator());
-        operators.put(OperatorNames.BOUNDARY, new StringBoundaryOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(String.class));
-        operators.put(OperatorNames.CHANGE_TYPE, new ChangeTypeOperator(String.class));
+        addOperatorIfEnabled(
+                "operator.value.string.replace.enabled",
+                OperatorNames.REPLACE,
+                StringReplacementOperator::new);
+        addOperatorIfEnabled(
+                "operator.value.string.addSpecialCharacters.enabled",
+                OperatorNames.ADD_SPECIAL_CHARACTERS,
+                StringAddSpecialCharactersMutationOperator::new);
+        addOperatorIfEnabled(
+                "operator.value.string.boundary.enabled",
+                OperatorNames.BOUNDARY,
+                StringBoundaryOperator::new);
+        addOperatorIfEnabled(
+                "operator.value.string.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(String.class));
+        addOperatorIfEnabled(
+                "operator.value.string.changeType.enabled",
+                OperatorNames.CHANGE_TYPE,
+                () -> new ChangeTypeOperator(String.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/headers/charset/CharsetMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/headers/charset/CharsetMutator.java
@@ -10,9 +10,15 @@ import es.us.isa.httpmutator.core.util.OperatorNames;
 public class CharsetMutator extends AbstractMutator {
     public CharsetMutator() {
         super();
-        prob = Float.parseFloat(readProperty("operator.sc.prob"));
-        operators.put(OperatorNames.REPLACE, new CharsetReplacementOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(CharsetMutator.class));
+        prob = Float.parseFloat(readProperty("operator.header.charset.prob"));
+        addOperatorIfEnabled(
+                "operator.header.charset.replace.enabled",
+                OperatorNames.REPLACE,
+                CharsetReplacementOperator::new);
+        addOperatorIfEnabled(
+                "operator.header.charset.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(CharsetMutator.class));
     }
 
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/headers/location/LocationMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/headers/location/LocationMutator.java
@@ -11,7 +11,13 @@ public class LocationMutator extends AbstractMutator {
     public LocationMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.header.location.prob"));
-        operators.put(OperatorNames.MUTATE, new LocationMutationOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(LocationMutator.class));
+        addOperatorIfEnabled(
+                "operator.header.location.mutate.enabled",
+                OperatorNames.MUTATE,
+                LocationMutationOperator::new);
+        addOperatorIfEnabled(
+                "operator.header.location.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(LocationMutator.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/headers/mediaType/MediaTypeMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/headers/mediaType/MediaTypeMutator.java
@@ -10,7 +10,13 @@ public class MediaTypeMutator extends AbstractMutator {
     public MediaTypeMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.header.mediaType.prob"));
-        operators.put(OperatorNames.REPLACE, new MediaTypeReplacementOperator());
-        operators.put(OperatorNames.NULL, new NullOperator(MediaTypeMutator.class));
+        addOperatorIfEnabled(
+                "operator.header.mediaType.replace.enabled",
+                OperatorNames.REPLACE,
+                MediaTypeReplacementOperator::new);
+        addOperatorIfEnabled(
+                "operator.header.mediaType.null.enabled",
+                OperatorNames.NULL,
+                () -> new NullOperator(MediaTypeMutator.class));
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/sc/StatusCodeMutator.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/sc/StatusCodeMutator.java
@@ -22,9 +22,18 @@ public class StatusCodeMutator extends AbstractMutator {
     public StatusCodeMutator() {
         super();
         prob = Float.parseFloat(readProperty("operator.sc.prob"));
-        operators.put(OperatorNames.REPLACE_WITH_20X, new StatusCodeReplacementWith20XOperator());
-        operators.put(OperatorNames.REPLACE_WITH_40X, new StatusCodeReplacementWith40XOperator());
-        operators.put(OperatorNames.REPLACE_WITH_50X, new StatusCodeReplacementWith50XOperator());
+        addOperatorIfEnabled(
+                "operator.sc.replaceWith20x.enabled",
+                OperatorNames.REPLACE_WITH_20X,
+                StatusCodeReplacementWith20XOperator::new);
+        addOperatorIfEnabled(
+                "operator.sc.replaceWith40x.enabled",
+                OperatorNames.REPLACE_WITH_40X,
+                StatusCodeReplacementWith40XOperator::new);
+        addOperatorIfEnabled(
+                "operator.sc.replaceWith50x.enabled",
+                OperatorNames.REPLACE_WITH_50X,
+                StatusCodeReplacementWith50XOperator::new);
     }
 
     public void getAllMutants(int statusCode, double probability, Consumer<MutantGroup> consumer) {
@@ -33,6 +42,8 @@ public class StatusCodeMutator extends AbstractMutator {
             JsonNode mutant = JsonNodeFactory.instance.numberNode((Integer) operator.mutate(statusCode));
             mutants.add(new Mutant("Status Code", mutant, this.getClass(), operator.getClass()));
         }
-        consumer.accept(new MutantGroup("Status Code", mutants));
+        if (!mutants.isEmpty()) {
+            consumer.accept(new MutantGroup("Status Code", mutants));
+        }
     }
 }

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/util/BodyPathIgnoreMatcher.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/util/BodyPathIgnoreMatcher.java
@@ -1,0 +1,94 @@
+package es.us.isa.httpmutator.core.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Normalizes and matches body mutation paths such as {@code Body/user/id}.
+ */
+public final class BodyPathIgnoreMatcher {
+
+    private static final String BODY_ROOT = "Body";
+    private static final String BODY_PREFIX = BODY_ROOT + "/";
+
+    private BodyPathIgnoreMatcher() {
+        // utility class
+    }
+
+    public static List<String> parsePaths(String rawPaths) {
+        if (rawPaths == null || rawPaths.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String[] parts = rawPaths.split(",");
+        List<String> paths = new ArrayList<String>();
+        for (String part : parts) {
+            paths.add(part);
+        }
+        return normalizePaths(paths);
+    }
+
+    public static List<String> normalizePaths(Collection<String> paths) {
+        if (paths == null || paths.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<String> normalized = new LinkedHashSet<String>();
+        for (String path : paths) {
+            String normalizedPath = normalizePath(path);
+            if (normalizedPath != null) {
+                normalized.add(normalizedPath);
+            }
+        }
+        return Collections.unmodifiableList(new ArrayList<String>(normalized));
+    }
+
+    public static String normalizePath(String path) {
+        if (path == null) {
+            return null;
+        }
+
+        String normalized = path.trim();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/") && normalized.length() > 1) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        if (BODY_ROOT.equals(normalized) || normalized.startsWith(BODY_PREFIX)) {
+            return normalized;
+        }
+        return BODY_PREFIX + normalized;
+    }
+
+    public static boolean matches(String candidatePath, Collection<String> ignoredPaths) {
+        if (ignoredPaths == null || ignoredPaths.isEmpty()) {
+            return false;
+        }
+
+        String normalizedCandidate = normalizePath(candidatePath);
+        if (normalizedCandidate == null) {
+            return false;
+        }
+
+        for (String ignoredPath : ignoredPaths) {
+            String normalizedIgnored = normalizePath(ignoredPath);
+            if (normalizedIgnored == null) {
+                continue;
+            }
+            if (normalizedCandidate.equals(normalizedIgnored)
+                    || normalizedCandidate.startsWith(normalizedIgnored + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/util/PropertyManager.java
+++ b/httpmutator-core/src/main/java/es/us/isa/httpmutator/core/util/PropertyManager.java
@@ -2,6 +2,9 @@ package es.us.isa.httpmutator.core.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -10,35 +13,50 @@ import java.util.Properties;
  */
 public class PropertyManager {
 
-	// private static String propertyFilePath = "src/main/resources/json-mutation.properties";
-	private static final String CLASSPATH_PROP = "json-mutation.properties";
+	private static final String CLASSPATH_PROP = "http-mutation.properties";
 
-	private static 	Properties properties = null;
+	private static Properties properties = null;
 
-	public static String readProperty(String name) {
-		loadProperties();
+	public static synchronized String readProperty(String name) {
+		ensurePropertiesLoaded();
 		return properties.getProperty(name);
 	}
 
-	public static void setProperty(String propertyName, String propertyValue) {
-		loadProperties();
+	public static synchronized void setProperty(String propertyName, String propertyValue) {
+		ensurePropertiesLoaded();
 		properties.setProperty(propertyName, propertyValue);
 	}
 
-	public static void resetProperties() {
-		properties = new Properties();
-		try (InputStream in = PropertyManager.class.getClassLoader().getResourceAsStream(CLASSPATH_PROP)) {
-            if (in == null) {
-                throw new IOException("Resource not found: " + CLASSPATH_PROP);
-            }
-            properties.load(in);
-        } catch (IOException e) {
-            System.err.printf("Error reading classpath config %s: %s%n", CLASSPATH_PROP, e.getMessage());
-            throw new RuntimeException("Cannot load mutation properties", e);
-        }
+	public static synchronized void resetProperties() {
+		properties = loadClasspathProperties();
 	}
 
-	private static void loadProperties() {
+	public static synchronized void loadProperties(Path propertiesFile) {
+		Objects.requireNonNull(propertiesFile, "propertiesFile must not be null");
+		Properties loadedProperties = loadClasspathProperties();
+		try (InputStream in = Files.newInputStream(propertiesFile)) {
+			loadedProperties.load(in);
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Cannot load mutation properties from " + propertiesFile, e);
+		}
+		properties = loadedProperties;
+	}
+
+	private static Properties loadClasspathProperties() {
+		Properties loadedProperties = new Properties();
+		try (InputStream in = PropertyManager.class.getClassLoader().getResourceAsStream(CLASSPATH_PROP)) {
+	            if (in == null) {
+	                throw new IOException("Resource not found: " + CLASSPATH_PROP);
+	            }
+	            loadedProperties.load(in);
+	        } catch (IOException e) {
+	            System.err.printf("Error reading classpath config %s: %s%n", CLASSPATH_PROP, e.getMessage());
+	            throw new RuntimeException("Cannot load mutation properties", e);
+	        }
+		return loadedProperties;
+	}
+
+	private static void ensurePropertiesLoaded() {
 		if (properties==null) {
 			resetProperties();
 		}

--- a/httpmutator-core/src/main/resources/graphql-mutation.properties
+++ b/httpmutator-core/src/main/resources/graphql-mutation.properties
@@ -3,6 +3,10 @@ operator.sc.enabled = true
 operator.header.enabled = true
 operator.body.enabled = true
 
+# Comma-separated Body paths to skip during path-based body mutation.
+# Examples: Body/id, /user/token, items/0/id
+mutation.body.ignore.paths=
+
 # Long mutation properties
 operator.value.long.enabled=true
 operator.value.long.min=-1000000

--- a/httpmutator-core/src/main/resources/graphql-mutation.properties
+++ b/httpmutator-core/src/main/resources/graphql-mutation.properties
@@ -1,0 +1,141 @@
+# high-level enable or disable mutator: status code, headers, body
+operator.sc.enabled = true
+operator.header.enabled = true
+operator.body.enabled = true
+
+# Long mutation properties
+operator.value.long.enabled=true
+operator.value.long.min=-1000000
+operator.value.long.max=1000000
+operator.value.long.prob=1
+operator.value.long.replace.enabled=true
+operator.value.long.null.enabled=true
+operator.value.long.changeType.enabled=true
+operator.value.long.weight.replace=0.1
+operator.value.long.weight.null=0.1
+operator.value.long.weight.changeType=0.1
+
+# Double mutation properties
+operator.value.double.enabled=true
+operator.value.double.min=-1000000
+operator.value.double.max=1000000
+operator.value.double.prob=1
+operator.value.double.replace.enabled=true
+operator.value.double.null.enabled=true
+operator.value.double.changeType.enabled=true
+operator.value.double.weight.replace=0.1
+operator.value.double.weight.null=0.1
+operator.value.double.weight.changeType=0.1
+
+# String mutation properties
+operator.value.string.enabled=true
+operator.value.string.includeLetters=true
+operator.value.string.includeNumbers=true
+operator.value.string.includeAscii=true
+operator.value.string.length.min=1
+operator.value.string.length.max=10
+operator.value.string.uppercase=EJEMPLO MAYUS
+operator.value.string.lowercase=ejemplo minus
+operator.value.string.prob=1
+operator.value.string.replace.enabled=true
+operator.value.string.addSpecialCharacters.enabled=true
+operator.value.string.boundary.enabled=true
+operator.value.string.null.enabled=true
+operator.value.string.changeType.enabled=true
+operator.value.string.weight.replace=0.1
+operator.value.string.weight.addSpecialCharacters=0.1
+operator.value.string.weight.boundary=0.1
+operator.value.string.weight.null=0.1
+operator.value.string.weight.changeType=0.1
+
+# Boolean mutation properties
+operator.value.boolean.enabled=true
+operator.value.boolean.prob=1
+operator.value.boolean.mutate.enabled=true
+operator.value.boolean.null.enabled=true
+operator.value.boolean.changeType.enabled=true
+operator.value.boolean.weight.mutate=0.1
+operator.value.boolean.weight.null=0.1
+operator.value.boolean.weight.changeType=0.1
+
+# Null mutation properties
+operator.value.null.enabled=true
+operator.value.null.prob=1
+operator.value.null.changeType.enabled=true
+operator.value.null.weight.changeType=0.1
+
+# Object mutation properties
+operator.object.enabled=true
+operator.object.addedElements.min=1
+operator.object.addedElements.max=4
+operator.object.removedElements.min=1
+operator.object.removedElements.max=4
+operator.object.removeObjectElement.min=1
+operator.object.removeObjectElement.max=4
+operator.object.mutations.min=1
+operator.object.mutations.max=2
+operator.object.prob=1
+operator.object.removeElement.enabled=true
+operator.object.removeObjectElement.enabled=true
+operator.object.addElement.enabled=true
+operator.object.null.enabled=true
+operator.object.changeType.enabled=true
+operator.object.weight.addElement=0.1
+operator.object.weight.removeElement=0.1
+operator.object.weight.removeObjectElement=0.1
+operator.object.weight.null=0.1
+operator.object.weight.changeType=0.1
+
+# Array mutation properties
+operator.array.enabled=true
+operator.array.addedElements.min=1
+operator.array.addedElements.max=4
+operator.array.removedElements.min=1
+operator.array.removedElements.max=4
+operator.array.mutations.min=1
+operator.array.mutations.max=2
+operator.array.prob=1
+operator.array.removeElement.enabled=true
+operator.array.empty.enabled=true
+operator.array.addElement.enabled=true
+operator.array.disorderElements.enabled=true
+operator.array.null.enabled=true
+operator.array.changeType.enabled=true
+operator.array.weight.addElement=0.1
+operator.array.weight.removeElement=0.1
+operator.array.weight.null=0.1
+operator.array.weight.empty=0.1
+operator.array.weight.changeType=0.1
+operator.array.weight.disorderElements=0.1
+
+# Status Code: disabled for GraphQL because application errors commonly use HTTP 200
+operator.sc.prob=1
+operator.sc.replaceWith20x.enabled=false
+operator.sc.replaceWith40x.enabled=false
+operator.sc.replaceWith50x.enabled=false
+operator.sc.weight.replaceWith20x=0.1
+operator.sc.weight.replaceWith40x=0.1
+operator.sc.weight.replaceWith50x=0.1
+
+# headers
+## media type
+operator.header.mediaType.enabled=true
+operator.header.mediaType.prob=1
+operator.header.mediaType.replace.enabled=true
+operator.header.mediaType.null.enabled=true
+operator.header.mediaType.weight.replace=0.1
+operator.header.mediaType.weight.null=0.1
+## charset
+operator.header.charset.enabled=true
+operator.header.charset.prob=1
+operator.header.charset.replace.enabled=true
+operator.header.charset.null.enabled=true
+operator.header.charset.weight.replace=0.1
+operator.header.charset.weight.null=0.1
+## location
+operator.header.location.enabled=true
+operator.header.location.prob=1
+operator.header.location.mutate.enabled=true
+operator.header.location.null.enabled=true
+operator.header.location.weight.mutate=0.1
+operator.header.location.weight.null=0.1

--- a/httpmutator-core/src/main/resources/http-mutation.properties
+++ b/httpmutator-core/src/main/resources/http-mutation.properties
@@ -3,6 +3,10 @@ operator.sc.enabled = true
 operator.header.enabled = true
 operator.body.enabled = true
 
+# Comma-separated Body paths to skip during path-based body mutation.
+# Examples: Body/id, /user/token, items/0/id
+mutation.body.ignore.paths=
+
 # Long mutation properties
 operator.value.long.enabled=true
 operator.value.long.min=-1000000

--- a/httpmutator-core/src/main/resources/http-mutation.properties
+++ b/httpmutator-core/src/main/resources/http-mutation.properties
@@ -1,6 +1,3 @@
-# General properties
-singleOrder.random=true
-
 # high-level enable or disable mutator: status code, headers, body
 operator.sc.enabled = true
 operator.header.enabled = true
@@ -10,11 +7,11 @@ operator.body.enabled = true
 operator.value.long.enabled=true
 operator.value.long.min=-1000000
 operator.value.long.max=1000000
-operator.value.long.delta=1
-operator.value.long.default=1
 operator.value.long.prob=1
+operator.value.long.replace.enabled=true
+operator.value.long.null.enabled=true
+operator.value.long.changeType.enabled=true
 operator.value.long.weight.replace=0.1
-operator.value.long.weight.mutate=0.1
 operator.value.long.weight.null=0.1
 operator.value.long.weight.changeType=0.1
 
@@ -22,11 +19,11 @@ operator.value.long.weight.changeType=0.1
 operator.value.double.enabled=true
 operator.value.double.min=-1000000
 operator.value.double.max=1000000
-operator.value.double.delta=0.5
-operator.value.double.default=0.1
 operator.value.double.prob=1
+operator.value.double.replace.enabled=true
+operator.value.double.null.enabled=true
+operator.value.double.changeType.enabled=true
 operator.value.double.weight.replace=0.1
-operator.value.double.weight.mutate=0.1
 operator.value.double.weight.null=0.1
 operator.value.double.weight.changeType=0.1
 
@@ -39,19 +36,24 @@ operator.value.string.length.min=1
 operator.value.string.length.max=10
 operator.value.string.uppercase=EJEMPLO MAYUS
 operator.value.string.lowercase=ejemplo minus
-operator.value.string.default=string
 operator.value.string.prob=1
+operator.value.string.replace.enabled=true
+operator.value.string.addSpecialCharacters.enabled=true
+operator.value.string.boundary.enabled=true
+operator.value.string.null.enabled=true
+operator.value.string.changeType.enabled=true
 operator.value.string.weight.replace=0.1
 operator.value.string.weight.addSpecialCharacters=0.1
-operator.value.string.weight.mutate=0.1
 operator.value.string.weight.boundary=0.1
 operator.value.string.weight.null=0.1
 operator.value.string.weight.changeType=0.1
 
 # Boolean mutation properties
 operator.value.boolean.enabled=true
-operator.value.boolean.default=true
 operator.value.boolean.prob=1
+operator.value.boolean.mutate.enabled=true
+operator.value.boolean.null.enabled=true
+operator.value.boolean.changeType.enabled=true
 operator.value.boolean.weight.mutate=0.1
 operator.value.boolean.weight.null=0.1
 operator.value.boolean.weight.changeType=0.1
@@ -59,6 +61,7 @@ operator.value.boolean.weight.changeType=0.1
 # Null mutation properties
 operator.value.null.enabled=true
 operator.value.null.prob=1
+operator.value.null.changeType.enabled=true
 operator.value.null.weight.changeType=0.1
 
 # Object mutation properties
@@ -69,18 +72,19 @@ operator.object.removedElements.min=1
 operator.object.removedElements.max=4
 operator.object.removeObjectElement.min=1
 operator.object.removeObjectElement.max=4
-operator.object.default={}
 operator.object.mutations.min=1
 operator.object.mutations.max=2
 operator.object.prob=1
-operator.object.weight.replace=0.1
+operator.object.removeElement.enabled=true
+operator.object.removeObjectElement.enabled=true
+operator.object.addElement.enabled=true
+operator.object.null.enabled=true
+operator.object.changeType.enabled=true
 operator.object.weight.addElement=0.1
 operator.object.weight.removeElement=0.1
 operator.object.weight.removeObjectElement=0.1
 operator.object.weight.null=0.1
-operator.object.weight.empty=0.1
 operator.object.weight.changeType=0.1
-operator.object.weight.disorderElements=0.1
 
 # Array mutation properties
 operator.array.enabled=true
@@ -88,11 +92,15 @@ operator.array.addedElements.min=1
 operator.array.addedElements.max=4
 operator.array.removedElements.min=1
 operator.array.removedElements.max=4
-operator.array.default=[]
 operator.array.mutations.min=1
 operator.array.mutations.max=2
 operator.array.prob=1
-operator.array.weight.replace=0.1
+operator.array.removeElement.enabled=true
+operator.array.empty.enabled=true
+operator.array.addElement.enabled=true
+operator.array.disorderElements.enabled=true
+operator.array.null.enabled=true
+operator.array.changeType.enabled=true
 operator.array.weight.addElement=0.1
 operator.array.weight.removeElement=0.1
 operator.array.weight.null=0.1
@@ -102,6 +110,9 @@ operator.array.weight.disorderElements=0.1
 
 # Status Code
 operator.sc.prob=1
+operator.sc.replaceWith20x.enabled=true
+operator.sc.replaceWith40x.enabled=true
+operator.sc.replaceWith50x.enabled=true
 operator.sc.weight.replaceWith20x=0.1
 operator.sc.weight.replaceWith40x=0.1
 operator.sc.weight.replaceWith50x=0.1
@@ -110,15 +121,21 @@ operator.sc.weight.replaceWith50x=0.1
 ## media type
 operator.header.mediaType.enabled=true
 operator.header.mediaType.prob=1
+operator.header.mediaType.replace.enabled=true
+operator.header.mediaType.null.enabled=true
 operator.header.mediaType.weight.replace=0.1
 operator.header.mediaType.weight.null=0.1
 ## charset
 operator.header.charset.enabled=true
 operator.header.charset.prob=1
+operator.header.charset.replace.enabled=true
+operator.header.charset.null.enabled=true
 operator.header.charset.weight.replace=0.1
 operator.header.charset.weight.null=0.1
 ## location
 operator.header.location.enabled=true
 operator.header.location.prob=1
+operator.header.location.mutate.enabled=true
+operator.header.location.null.enabled=true
 operator.header.location.weight.mutate=0.1
 operator.header.location.weight.null=0.1

--- a/httpmutator-core/src/main/resources/rest-mutation.properties
+++ b/httpmutator-core/src/main/resources/rest-mutation.properties
@@ -3,6 +3,10 @@ operator.sc.enabled = true
 operator.header.enabled = true
 operator.body.enabled = true
 
+# Comma-separated Body paths to skip during path-based body mutation.
+# Examples: Body/id, /user/token, items/0/id
+mutation.body.ignore.paths=
+
 # Long mutation properties
 operator.value.long.enabled=true
 operator.value.long.min=-1000000

--- a/httpmutator-core/src/main/resources/rest-mutation.properties
+++ b/httpmutator-core/src/main/resources/rest-mutation.properties
@@ -1,0 +1,141 @@
+# high-level enable or disable mutator: status code, headers, body
+operator.sc.enabled = true
+operator.header.enabled = true
+operator.body.enabled = true
+
+# Long mutation properties
+operator.value.long.enabled=true
+operator.value.long.min=-1000000
+operator.value.long.max=1000000
+operator.value.long.prob=1
+operator.value.long.replace.enabled=true
+operator.value.long.null.enabled=true
+operator.value.long.changeType.enabled=true
+operator.value.long.weight.replace=0.1
+operator.value.long.weight.null=0.1
+operator.value.long.weight.changeType=0.1
+
+# Double mutation properties
+operator.value.double.enabled=true
+operator.value.double.min=-1000000
+operator.value.double.max=1000000
+operator.value.double.prob=1
+operator.value.double.replace.enabled=true
+operator.value.double.null.enabled=true
+operator.value.double.changeType.enabled=true
+operator.value.double.weight.replace=0.1
+operator.value.double.weight.null=0.1
+operator.value.double.weight.changeType=0.1
+
+# String mutation properties
+operator.value.string.enabled=true
+operator.value.string.includeLetters=true
+operator.value.string.includeNumbers=true
+operator.value.string.includeAscii=true
+operator.value.string.length.min=1
+operator.value.string.length.max=10
+operator.value.string.uppercase=EJEMPLO MAYUS
+operator.value.string.lowercase=ejemplo minus
+operator.value.string.prob=1
+operator.value.string.replace.enabled=true
+operator.value.string.addSpecialCharacters.enabled=true
+operator.value.string.boundary.enabled=true
+operator.value.string.null.enabled=true
+operator.value.string.changeType.enabled=true
+operator.value.string.weight.replace=0.1
+operator.value.string.weight.addSpecialCharacters=0.1
+operator.value.string.weight.boundary=0.1
+operator.value.string.weight.null=0.1
+operator.value.string.weight.changeType=0.1
+
+# Boolean mutation properties
+operator.value.boolean.enabled=true
+operator.value.boolean.prob=1
+operator.value.boolean.mutate.enabled=true
+operator.value.boolean.null.enabled=true
+operator.value.boolean.changeType.enabled=true
+operator.value.boolean.weight.mutate=0.1
+operator.value.boolean.weight.null=0.1
+operator.value.boolean.weight.changeType=0.1
+
+# Null mutation properties
+operator.value.null.enabled=true
+operator.value.null.prob=1
+operator.value.null.changeType.enabled=true
+operator.value.null.weight.changeType=0.1
+
+# Object mutation properties
+operator.object.enabled=true
+operator.object.addedElements.min=1
+operator.object.addedElements.max=4
+operator.object.removedElements.min=1
+operator.object.removedElements.max=4
+operator.object.removeObjectElement.min=1
+operator.object.removeObjectElement.max=4
+operator.object.mutations.min=1
+operator.object.mutations.max=2
+operator.object.prob=1
+operator.object.removeElement.enabled=true
+operator.object.removeObjectElement.enabled=true
+operator.object.addElement.enabled=true
+operator.object.null.enabled=true
+operator.object.changeType.enabled=true
+operator.object.weight.addElement=0.1
+operator.object.weight.removeElement=0.1
+operator.object.weight.removeObjectElement=0.1
+operator.object.weight.null=0.1
+operator.object.weight.changeType=0.1
+
+# Array mutation properties
+operator.array.enabled=true
+operator.array.addedElements.min=1
+operator.array.addedElements.max=4
+operator.array.removedElements.min=1
+operator.array.removedElements.max=4
+operator.array.mutations.min=1
+operator.array.mutations.max=2
+operator.array.prob=1
+operator.array.removeElement.enabled=true
+operator.array.empty.enabled=true
+operator.array.addElement.enabled=true
+operator.array.disorderElements.enabled=true
+operator.array.null.enabled=true
+operator.array.changeType.enabled=true
+operator.array.weight.addElement=0.1
+operator.array.weight.removeElement=0.1
+operator.array.weight.null=0.1
+operator.array.weight.empty=0.1
+operator.array.weight.changeType=0.1
+operator.array.weight.disorderElements=0.1
+
+# Status Code
+operator.sc.prob=1
+operator.sc.replaceWith20x.enabled=true
+operator.sc.replaceWith40x.enabled=true
+operator.sc.replaceWith50x.enabled=true
+operator.sc.weight.replaceWith20x=0.1
+operator.sc.weight.replaceWith40x=0.1
+operator.sc.weight.replaceWith50x=0.1
+
+# headers
+## media type
+operator.header.mediaType.enabled=true
+operator.header.mediaType.prob=1
+operator.header.mediaType.replace.enabled=true
+operator.header.mediaType.null.enabled=true
+operator.header.mediaType.weight.replace=0.1
+operator.header.mediaType.weight.null=0.1
+## charset
+operator.header.charset.enabled=true
+operator.header.charset.prob=1
+operator.header.charset.replace.enabled=true
+operator.header.charset.null.enabled=true
+operator.header.charset.weight.replace=0.1
+operator.header.charset.weight.null=0.1
+## location
+operator.header.location.enabled=true
+operator.header.location.prob=1
+operator.header.location.mutate.enabled=true
+operator.header.location.null.enabled=true
+operator.header.location.weight.mutate=0.1
+operator.header.location.weight.null=0.1

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/BodyPathIgnoreTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/BodyPathIgnoreTest.java
@@ -1,0 +1,144 @@
+package es.us.isa.httpmutator.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.us.isa.httpmutator.core.model.Mutant;
+import es.us.isa.httpmutator.core.model.StandardHttpResponse;
+import es.us.isa.httpmutator.core.strategy.AllOperatorsStrategy;
+import es.us.isa.httpmutator.core.util.PropertyManager;
+import es.us.isa.httpmutator.core.util.RandomUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+public class BodyPathIgnoreTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @After
+    public void resetProperties() {
+        PropertyManager.resetProperties();
+        RandomUtils.setSeed(42L);
+    }
+
+    @Test
+    public void ignoredBodyPathSkipsThatSubtreeOnly() throws Exception {
+        StandardHttpResponse original = response("{\"user\":{\"id\":1,\"name\":\"Ada\"},\"status\":\"active\"}");
+        HttpMutator mutator = new HttpMutator(42L)
+                .withMutationStrategy(new AllOperatorsStrategy())
+                .withIgnoredBodyPaths(Collections.singleton("Body/user"));
+
+        List<String> paths = mutantPaths(mutator, original);
+
+        Assert.assertFalse("Ignored subtree should not produce mutants",
+                containsPathOrDescendant(paths, "Body/user"));
+        Assert.assertTrue("Sibling body field should still produce mutants",
+                paths.contains("Body/status"));
+    }
+
+    @Test
+    public void ignoredLeafPathDoesNotSkipSiblings() throws Exception {
+        StandardHttpResponse original = response("{\"items\":[{\"id\":1,\"name\":\"alpha\"}],\"other\":true}");
+        HttpMutator mutator = new HttpMutator(42L)
+                .withMutationStrategy(new AllOperatorsStrategy())
+                .addIgnoredBodyPath("/items/0/id");
+
+        List<String> paths = mutantPaths(mutator, original);
+
+        Assert.assertFalse("Ignored leaf should not produce mutants",
+                containsPathOrDescendant(paths, "Body/items/0/id"));
+        Assert.assertTrue("Sibling leaf should still produce mutants",
+                paths.contains("Body/items/0/name"));
+    }
+
+    @Test
+    public void ignoredBodyRootSkipsOnlyBodyMutants() throws Exception {
+        StandardHttpResponse original = response("{\"id\":1,\"name\":\"Ada\"}");
+        HttpMutator mutator = new HttpMutator(42L)
+                .withMutationStrategy(new AllOperatorsStrategy())
+                .addIgnoredBodyPath("Body");
+
+        List<String> paths = mutantPaths(mutator, original);
+
+        Assert.assertFalse("No body mutants should be produced",
+                paths.stream().anyMatch(path -> path.equals("Body") || path.startsWith("Body/")));
+        Assert.assertTrue("Status code mutants should still be produced",
+                paths.contains("Status Code"));
+    }
+
+    @Test
+    public void ignoredBodyPathsAreNormalized() {
+        HttpMutator mutator = new HttpMutator(42L)
+                .withIgnoredBodyPaths(Arrays.asList("Body/user", "/token", "items/0/id", "  ", null));
+
+        Assert.assertEquals(Arrays.asList("Body/user", "Body/token", "Body/items/0/id"),
+                new ArrayList<String>(mutator.getIgnoredBodyPaths()));
+    }
+
+    @Test
+    public void propertiesFileConfiguresIgnoredBodyPaths() throws Exception {
+        Path override = temporaryFolder.newFile("ignore.properties").toPath();
+        Files.write(override,
+                "mutation.body.ignore.paths=/user\n".getBytes(StandardCharsets.UTF_8));
+        StandardHttpResponse original = response("{\"user\":{\"id\":1},\"status\":\"active\"}");
+        HttpMutator mutator = new HttpMutator(42L, override)
+                .withMutationStrategy(new AllOperatorsStrategy());
+
+        List<String> paths = mutantPaths(mutator, original);
+
+        Assert.assertEquals(Collections.singletonList("Body/user"),
+                new ArrayList<String>(mutator.getIgnoredBodyPaths()));
+        Assert.assertFalse("Ignored path from properties should be applied",
+                containsPathOrDescendant(paths, "Body/user"));
+        Assert.assertTrue("Unignored sibling should still be mutated",
+                paths.contains("Body/status"));
+    }
+
+    @Test
+    public void javaApiCanOverrideAndAppendPropertiesIgnoredBodyPaths() throws Exception {
+        Path override = temporaryFolder.newFile("ignore.properties").toPath();
+        Files.write(override,
+                "mutation.body.ignore.paths=/user\n".getBytes(StandardCharsets.UTF_8));
+        HttpMutator mutator = new HttpMutator(42L, override)
+                .withIgnoredBodyPaths(Collections.singleton("status"))
+                .addIgnoredBodyPath("items/0/id");
+
+        Assert.assertEquals(Arrays.asList("Body/status", "Body/items/0/id"),
+                new ArrayList<String>(mutator.getIgnoredBodyPaths()));
+    }
+
+    private static StandardHttpResponse response(String bodyJson) throws Exception {
+        JsonNode body = MAPPER.readTree(bodyJson);
+        return StandardHttpResponse.of(200, new HashMap<String, Object>(), body);
+    }
+
+    private static List<String> mutantPaths(HttpMutator mutator, StandardHttpResponse original) throws Exception {
+        final List<String> paths = new ArrayList<String>();
+        mutator.mutate(original, "body-ignore-test", (mutated, mutant) -> paths.add(mutant.getOriginalJsonPath()));
+        mutator.close();
+        return paths;
+    }
+
+    private static boolean containsPathOrDescendant(List<String> paths, String ignoredPath) {
+        for (String path : paths) {
+            if (path.equals(ignoredPath) || path.startsWith(ignoredPath + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/ConfigurationPropertiesCoverageTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/ConfigurationPropertiesCoverageTest.java
@@ -1,0 +1,171 @@
+package es.us.isa.httpmutator.core;
+
+import es.us.isa.httpmutator.core.util.PropertyManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class ConfigurationPropertiesCoverageTest {
+
+    private static final Set<String> ACTIVE_PROPERTIES = new TreeSet<>(Arrays.asList(
+            "operator.sc.enabled",
+            "operator.header.enabled",
+            "operator.body.enabled",
+
+            "operator.value.long.enabled",
+            "operator.value.long.min",
+            "operator.value.long.max",
+            "operator.value.long.prob",
+            "operator.value.long.replace.enabled",
+            "operator.value.long.null.enabled",
+            "operator.value.long.changeType.enabled",
+            "operator.value.long.weight.replace",
+            "operator.value.long.weight.null",
+            "operator.value.long.weight.changeType",
+
+            "operator.value.double.enabled",
+            "operator.value.double.min",
+            "operator.value.double.max",
+            "operator.value.double.prob",
+            "operator.value.double.replace.enabled",
+            "operator.value.double.null.enabled",
+            "operator.value.double.changeType.enabled",
+            "operator.value.double.weight.replace",
+            "operator.value.double.weight.null",
+            "operator.value.double.weight.changeType",
+
+            "operator.value.string.enabled",
+            "operator.value.string.includeLetters",
+            "operator.value.string.includeNumbers",
+            "operator.value.string.includeAscii",
+            "operator.value.string.length.min",
+            "operator.value.string.length.max",
+            "operator.value.string.uppercase",
+            "operator.value.string.lowercase",
+            "operator.value.string.prob",
+            "operator.value.string.replace.enabled",
+            "operator.value.string.addSpecialCharacters.enabled",
+            "operator.value.string.boundary.enabled",
+            "operator.value.string.null.enabled",
+            "operator.value.string.changeType.enabled",
+            "operator.value.string.weight.replace",
+            "operator.value.string.weight.addSpecialCharacters",
+            "operator.value.string.weight.boundary",
+            "operator.value.string.weight.null",
+            "operator.value.string.weight.changeType",
+
+            "operator.value.boolean.enabled",
+            "operator.value.boolean.prob",
+            "operator.value.boolean.mutate.enabled",
+            "operator.value.boolean.null.enabled",
+            "operator.value.boolean.changeType.enabled",
+            "operator.value.boolean.weight.mutate",
+            "operator.value.boolean.weight.null",
+            "operator.value.boolean.weight.changeType",
+
+            "operator.value.null.enabled",
+            "operator.value.null.prob",
+            "operator.value.null.changeType.enabled",
+            "operator.value.null.weight.changeType",
+
+            "operator.object.enabled",
+            "operator.object.addedElements.min",
+            "operator.object.addedElements.max",
+            "operator.object.removedElements.min",
+            "operator.object.removedElements.max",
+            "operator.object.removeObjectElement.min",
+            "operator.object.removeObjectElement.max",
+            "operator.object.mutations.min",
+            "operator.object.mutations.max",
+            "operator.object.prob",
+            "operator.object.removeElement.enabled",
+            "operator.object.removeObjectElement.enabled",
+            "operator.object.addElement.enabled",
+            "operator.object.null.enabled",
+            "operator.object.changeType.enabled",
+            "operator.object.weight.addElement",
+            "operator.object.weight.removeElement",
+            "operator.object.weight.removeObjectElement",
+            "operator.object.weight.null",
+            "operator.object.weight.changeType",
+
+            "operator.array.enabled",
+            "operator.array.addedElements.min",
+            "operator.array.addedElements.max",
+            "operator.array.removedElements.min",
+            "operator.array.removedElements.max",
+            "operator.array.mutations.min",
+            "operator.array.mutations.max",
+            "operator.array.prob",
+            "operator.array.removeElement.enabled",
+            "operator.array.empty.enabled",
+            "operator.array.addElement.enabled",
+            "operator.array.disorderElements.enabled",
+            "operator.array.null.enabled",
+            "operator.array.changeType.enabled",
+            "operator.array.weight.addElement",
+            "operator.array.weight.removeElement",
+            "operator.array.weight.empty",
+            "operator.array.weight.null",
+            "operator.array.weight.changeType",
+            "operator.array.weight.disorderElements",
+
+            "operator.sc.prob",
+            "operator.sc.replaceWith20x.enabled",
+            "operator.sc.replaceWith40x.enabled",
+            "operator.sc.replaceWith50x.enabled",
+            "operator.sc.weight.replaceWith20x",
+            "operator.sc.weight.replaceWith40x",
+            "operator.sc.weight.replaceWith50x",
+
+            "operator.header.mediaType.enabled",
+            "operator.header.mediaType.prob",
+            "operator.header.mediaType.replace.enabled",
+            "operator.header.mediaType.null.enabled",
+            "operator.header.mediaType.weight.replace",
+            "operator.header.mediaType.weight.null",
+
+            "operator.header.charset.enabled",
+            "operator.header.charset.prob",
+            "operator.header.charset.replace.enabled",
+            "operator.header.charset.null.enabled",
+            "operator.header.charset.weight.replace",
+            "operator.header.charset.weight.null",
+
+            "operator.header.location.enabled",
+            "operator.header.location.prob",
+            "operator.header.location.mutate.enabled",
+            "operator.header.location.null.enabled",
+            "operator.header.location.weight.mutate",
+            "operator.header.location.weight.null"
+    ));
+
+    @Test
+    public void defaultConfigurationContainsOnlyActiveProperties() throws Exception {
+        Properties defaults = load("http-mutation.properties");
+
+        Assert.assertEquals(ACTIVE_PROPERTIES, new TreeSet<>(defaults.stringPropertyNames()));
+    }
+
+    @Test
+    public void restAndGraphqlConfigurationsUseSamePropertyKeysAsDefault() throws Exception {
+        Set<String> defaults = new TreeSet<>(load("http-mutation.properties").stringPropertyNames());
+
+        Assert.assertEquals(defaults, new TreeSet<>(load("rest-mutation.properties").stringPropertyNames()));
+        Assert.assertEquals(defaults, new TreeSet<>(load("graphql-mutation.properties").stringPropertyNames()));
+    }
+
+    private Properties load(String resourceName) throws Exception {
+        Properties properties = new Properties();
+        try (InputStream input = PropertyManager.class.getClassLoader().getResourceAsStream(resourceName)) {
+            Assert.assertNotNull("Missing classpath resource " + resourceName, input);
+            properties.load(input);
+        }
+        return properties;
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/ConfigurationPropertiesCoverageTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/ConfigurationPropertiesCoverageTest.java
@@ -16,6 +16,7 @@ public class ConfigurationPropertiesCoverageTest {
             "operator.sc.enabled",
             "operator.header.enabled",
             "operator.body.enabled",
+            "mutation.body.ignore.paths",
 
             "operator.value.long.enabled",
             "operator.value.long.min",

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/HttpMutatorCliTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/HttpMutatorCliTest.java
@@ -1,0 +1,72 @@
+package es.us.isa.httpmutator.core;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class HttpMutatorCliTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void parsesPropertiesFileArgument() throws Exception {
+        Path input = temporaryFolder.newFile("traffic.jsonl").toPath();
+        Path properties = temporaryFolder.newFile("custom.properties").toPath();
+        Files.write(properties,
+                "operator.sc.replaceWith40x.enabled=false\n".getBytes(StandardCharsets.UTF_8));
+
+        Object config = parse(
+                "--input", input.toString(),
+                "--format", "jsonl",
+                "--properties", properties.toString());
+
+        Assert.assertEquals(properties, getPathField(config, "propertiesFile"));
+    }
+
+    @Test
+    public void rejectsUnreadablePropertiesFileArgument() throws Exception {
+        Path input = temporaryFolder.newFile("traffic.jsonl").toPath();
+        Path missingProperties = temporaryFolder.getRoot().toPath().resolve("missing.properties");
+
+        try {
+            parse(
+                    "--input", input.toString(),
+                    "--format", "jsonl",
+                    "--properties", missingProperties.toString());
+            Assert.fail("Expected missing properties file to be rejected");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("--properties"));
+            Assert.assertTrue(e.getMessage().contains(missingProperties.toString()));
+        }
+    }
+
+    private static Object parse(String... args) throws Exception {
+        Class<?> cliConfigClass = Class.forName("es.us.isa.httpmutator.core.HttpMutatorCli$CliConfig");
+        Method parse = cliConfigClass.getDeclaredMethod("parse", String[].class);
+        parse.setAccessible(true);
+        try {
+            return parse.invoke(null, (Object) args);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) cause;
+            }
+            throw e;
+        }
+    }
+
+    private static Path getPathField(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (Path) field.get(target);
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/HttpMutatorPerMutantMetadataTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/HttpMutatorPerMutantMetadataTest.java
@@ -1,0 +1,46 @@
+package es.us.isa.httpmutator.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.us.isa.httpmutator.core.model.Mutant;
+import es.us.isa.httpmutator.core.model.StandardHttpResponse;
+import es.us.isa.httpmutator.core.strategy.AllOperatorsStrategy;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class HttpMutatorPerMutantMetadataTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void mutateWithBiConsumerProvidesMutatedResponseAndMutantMetadata() throws Exception {
+        JsonNode body = MAPPER.readTree("{\"id\": 7, \"name\": \"alpha\", \"ok\": true}");
+        StandardHttpResponse original = StandardHttpResponse.of(200, new HashMap<String, Object>(), body);
+
+        HttpMutator mutator = new HttpMutator(42L).withMutationStrategy(new AllOperatorsStrategy());
+
+        final List<StandardHttpResponse> mutatedResponses = new ArrayList<StandardHttpResponse>();
+        final List<Mutant> mutants = new ArrayList<Mutant>();
+
+        mutator.mutate(original, "metadata-request", (mutated, mutant) -> {
+            mutatedResponses.add(mutated);
+            mutants.add(mutant);
+        });
+        mutator.close();
+
+        Assert.assertFalse("Expected at least one mutated response", mutatedResponses.isEmpty());
+        Assert.assertEquals("Each mutated response should have matching mutant metadata",
+                mutatedResponses.size(), mutants.size());
+
+        Mutant first = mutants.get(0);
+        Assert.assertNotNull("Mutator class should be available", first.getMutatorClassName());
+        Assert.assertNotNull("Operator class should be available", first.getOperatorClassName());
+        Assert.assertNotNull("Original JSON path should be available", first.getOriginalJsonPath());
+        Assert.assertFalse("Operator class name should not be empty",
+                first.getOperatorClassName().trim().isEmpty());
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/OperatorConfigurationTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/OperatorConfigurationTest.java
@@ -1,0 +1,66 @@
+package es.us.isa.httpmutator.core;
+
+import es.us.isa.httpmutator.core.util.PropertyManager;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class OperatorConfigurationTest {
+
+    @After
+    public void resetProperties() {
+        PropertyManager.resetProperties();
+    }
+
+    @Test
+    public void missingOperatorEnabledPropertyDefaultsToEnabled() {
+        TestMutator mutator = new TestMutator();
+
+        mutator.register("operator.test.missing.enabled", new AtomicBoolean());
+
+        Assert.assertTrue(mutator.getOperators().containsKey("test"));
+    }
+
+    @Test
+    public void disabledOperatorIsNotInstantiatedOrRegistered() {
+        PropertyManager.setProperty("operator.test.disabled.enabled", "false");
+        AtomicBoolean instantiated = new AtomicBoolean();
+        TestMutator mutator = new TestMutator();
+
+        mutator.register("operator.test.disabled.enabled", instantiated);
+
+        Assert.assertFalse(instantiated.get());
+        Assert.assertFalse(mutator.getOperators().containsKey("test"));
+    }
+
+    @Test
+    public void invalidOperatorEnabledPropertyIsRejected() {
+        PropertyManager.setProperty("operator.test.invalid.enabled", "sometimes");
+        TestMutator mutator = new TestMutator();
+
+        try {
+            mutator.register("operator.test.invalid.enabled", new AtomicBoolean());
+            Assert.fail("Expected invalid boolean property to be rejected");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("operator.test.invalid.enabled"));
+        }
+    }
+
+    private static final class TestMutator extends AbstractMutator {
+        void register(String propertyName, AtomicBoolean instantiated) {
+            addOperatorIfEnabled(propertyName, "test", () -> {
+                instantiated.set(true);
+                return new TestOperator();
+            });
+        }
+    }
+
+    private static final class TestOperator extends AbstractOperator {
+        @Override
+        protected Object doMutate(Object element) {
+            return element;
+        }
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/OperatorSelectionTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/OperatorSelectionTest.java
@@ -1,0 +1,175 @@
+package es.us.isa.httpmutator.core;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import es.us.isa.httpmutator.core.body.array.ArrayMutator;
+import es.us.isa.httpmutator.core.body.object.ObjectMutator;
+import es.us.isa.httpmutator.core.body.value.boolean0.BooleanMutator;
+import es.us.isa.httpmutator.core.body.value.double0.DoubleMutator;
+import es.us.isa.httpmutator.core.body.value.long0.LongMutator;
+import es.us.isa.httpmutator.core.body.value.null0.NullMutator;
+import es.us.isa.httpmutator.core.body.value.string0.StringMutator;
+import es.us.isa.httpmutator.core.headers.charset.CharsetMutator;
+import es.us.isa.httpmutator.core.headers.location.LocationMutator;
+import es.us.isa.httpmutator.core.headers.mediaType.MediaTypeMutator;
+import es.us.isa.httpmutator.core.sc.StatusCodeMutator;
+import es.us.isa.httpmutator.core.util.PropertyManager;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+public class OperatorSelectionTest {
+
+    @After
+    public void resetProperties() {
+        PropertyManager.resetProperties();
+    }
+
+    @Test
+    public void statusCodeOperatorsCanAllBeDisabled() {
+        assertAllOperatorsCanBeDisabled(
+                StatusCodeMutator::new,
+                "operator.sc.replaceWith20x.enabled",
+                "operator.sc.replaceWith40x.enabled",
+                "operator.sc.replaceWith50x.enabled");
+    }
+
+    @Test
+    public void headerOperatorsCanAllBeDisabled() {
+        assertAllOperatorsCanBeDisabled(
+                MediaTypeMutator::new,
+                "operator.header.mediaType.replace.enabled",
+                "operator.header.mediaType.null.enabled");
+        assertAllOperatorsCanBeDisabled(
+                CharsetMutator::new,
+                "operator.header.charset.replace.enabled",
+                "operator.header.charset.null.enabled");
+        assertAllOperatorsCanBeDisabled(
+                LocationMutator::new,
+                "operator.header.location.mutate.enabled",
+                "operator.header.location.null.enabled");
+    }
+
+    @Test
+    public void primitiveValueOperatorsCanAllBeDisabled() {
+        assertAllOperatorsCanBeDisabled(
+                LongMutator::new,
+                "operator.value.long.replace.enabled",
+                "operator.value.long.null.enabled",
+                "operator.value.long.changeType.enabled");
+        assertAllOperatorsCanBeDisabled(
+                DoubleMutator::new,
+                "operator.value.double.replace.enabled",
+                "operator.value.double.null.enabled",
+                "operator.value.double.changeType.enabled");
+        assertAllOperatorsCanBeDisabled(
+                StringMutator::new,
+                "operator.value.string.replace.enabled",
+                "operator.value.string.addSpecialCharacters.enabled",
+                "operator.value.string.boundary.enabled",
+                "operator.value.string.null.enabled",
+                "operator.value.string.changeType.enabled");
+        assertAllOperatorsCanBeDisabled(
+                BooleanMutator::new,
+                "operator.value.boolean.mutate.enabled",
+                "operator.value.boolean.null.enabled",
+                "operator.value.boolean.changeType.enabled");
+        assertAllOperatorsCanBeDisabled(
+                NullMutator::new,
+                "operator.value.null.changeType.enabled");
+    }
+
+    @Test
+    public void containerOperatorsCanAllBeDisabled() {
+        assertAllOperatorsCanBeDisabled(
+                ObjectMutator::new,
+                "operator.object.removeElement.enabled",
+                "operator.object.removeObjectElement.enabled",
+                "operator.object.addElement.enabled",
+                "operator.object.null.enabled",
+                "operator.object.changeType.enabled");
+        assertAllOperatorsCanBeDisabled(
+                ArrayMutator::new,
+                "operator.array.removeElement.enabled",
+                "operator.array.empty.enabled",
+                "operator.array.addElement.enabled",
+                "operator.array.disorderElements.enabled",
+                "operator.array.null.enabled",
+                "operator.array.changeType.enabled");
+    }
+
+    @Test
+    public void disablingOneOperatorLeavesOtherOperatorsEnabled() {
+        PropertyManager.setProperty("operator.sc.replaceWith20x.enabled", "false");
+
+        StatusCodeMutator mutator = new StatusCodeMutator();
+
+        Assert.assertFalse(mutator.getOperators().containsKey("replaceWith20x"));
+        Assert.assertTrue(mutator.getOperators().containsKey("replaceWith40x"));
+        Assert.assertTrue(mutator.getOperators().containsKey("replaceWith50x"));
+    }
+
+    @Test
+    public void statusCodeMutatorDoesNotEmitEmptyGroup() {
+        disable(
+                "operator.sc.replaceWith20x.enabled",
+                "operator.sc.replaceWith40x.enabled",
+                "operator.sc.replaceWith50x.enabled");
+        StatusCodeMutator mutator = new StatusCodeMutator();
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        mutator.getAllMutants(200, 1.0, group -> invoked.set(true));
+
+        Assert.assertFalse(invoked.get());
+    }
+
+    @Test
+    public void disabledContainerOperatorsLeaveRootContainersUnchanged() {
+        disable(
+                "operator.object.removeElement.enabled",
+                "operator.object.removeObjectElement.enabled",
+                "operator.object.addElement.enabled",
+                "operator.object.null.enabled",
+                "operator.object.changeType.enabled");
+        ObjectMutator objectMutator = new ObjectMutator();
+        ObjectNode object = JsonNodeFactory.instance.objectNode().put("id", 1);
+
+        Assert.assertEquals(object, objectMutator.getMutatedNode(object.deepCopy()));
+
+        PropertyManager.resetProperties();
+        disable(
+                "operator.array.removeElement.enabled",
+                "operator.array.empty.enabled",
+                "operator.array.addElement.enabled",
+                "operator.array.disorderElements.enabled",
+                "operator.array.null.enabled",
+                "operator.array.changeType.enabled");
+        ArrayMutator arrayMutator = new ArrayMutator();
+        ArrayNode array = JsonNodeFactory.instance.arrayNode().add(1);
+
+        Assert.assertEquals(array, arrayMutator.getMutatedNode(array.deepCopy()));
+    }
+
+    private void assertAllOperatorsCanBeDisabled(
+            Supplier<? extends AbstractMutator> mutatorSupplier,
+            String... enabledProperties) {
+        PropertyManager.resetProperties();
+        disable(enabledProperties);
+
+        AbstractMutator mutator = mutatorSupplier.get();
+
+        Assert.assertTrue(
+                "Expected no operators after disabling " + String.join(", ", enabledProperties),
+                mutator.getOperators().isEmpty());
+    }
+
+    private void disable(String... enabledProperties) {
+        for (String property : enabledProperties) {
+            PropertyManager.setProperty(property, "false");
+        }
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/PropertiesFileConfigurationTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/PropertiesFileConfigurationTest.java
@@ -1,0 +1,178 @@
+package es.us.isa.httpmutator.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.us.isa.httpmutator.core.util.PropertyManager;
+import es.us.isa.httpmutator.core.util.RandomUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class PropertiesFileConfigurationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @After
+    public void resetProperties() {
+        PropertyManager.resetProperties();
+        RandomUtils.setSeed(42L);
+    }
+
+    @Test
+    public void defaultConfigurationUsesHttpMutationResourceName() {
+        ClassLoader loader = PropertyManager.class.getClassLoader();
+
+        Assert.assertNotNull(loader.getResource("http-mutation.properties"));
+        Assert.assertNull(loader.getResource("json-mutation.properties"));
+    }
+
+    @Test
+    public void exampleConfigurationsAreClasspathResources() {
+        ClassLoader loader = PropertyManager.class.getClassLoader();
+
+        Assert.assertNotNull(loader.getResource("rest-mutation.properties"));
+        Assert.assertNotNull(loader.getResource("graphql-mutation.properties"));
+    }
+
+    @Test
+    public void loadPropertiesOverlaysDefaultConfiguration() throws Exception {
+        Path override = temporaryFolder.newFile("override.properties").toPath();
+        Files.write(override,
+                ("operator.sc.replaceWith40x.enabled=false\n"
+                        + "operator.value.string.length.max=256\n").getBytes(StandardCharsets.UTF_8));
+
+        PropertyManager.loadProperties(override);
+
+        Assert.assertEquals("false", PropertyManager.readProperty("operator.sc.replaceWith40x.enabled"));
+        Assert.assertEquals("true", PropertyManager.readProperty("operator.sc.replaceWith20x.enabled"));
+        Assert.assertEquals("256", PropertyManager.readProperty("operator.value.string.length.max"));
+    }
+
+    @Test
+    public void restConfigurationMatchesDefaultOperatorSelection() throws Exception {
+        Properties defaults = loadClasspathProperties("http-mutation.properties");
+        Properties rest = loadClasspathProperties("rest-mutation.properties");
+
+        Assert.assertEquals(defaults, rest);
+        Assert.assertEquals(operatorEnabledKeys(defaults), operatorEnabledKeys(rest));
+        for (String key : operatorEnabledKeys(rest)) {
+            Assert.assertEquals("REST should enable " + key, "true", rest.getProperty(key));
+            Assert.assertEquals("Default should match REST for " + key,
+                    rest.getProperty(key), defaults.getProperty(key));
+        }
+    }
+
+    @Test
+    public void graphqlConfigurationDisablesOnlyStatusCodeOperators() throws Exception {
+        Properties rest = loadClasspathProperties("rest-mutation.properties");
+        Properties graphql = loadClasspathProperties("graphql-mutation.properties");
+        Set<String> enabledKeys = operatorEnabledKeys(rest);
+
+        Assert.assertEquals(enabledKeys, operatorEnabledKeys(graphql));
+        for (String key : enabledKeys) {
+            String expected = key.startsWith("operator.sc.") ? "false" : "true";
+            Assert.assertEquals("Unexpected GraphQL value for " + key, expected, graphql.getProperty(key));
+        }
+    }
+
+    @Test
+    public void graphqlPropertiesFileGeneratesHeaderAndBodyButNoStatusMutants() throws Exception {
+        Path graphql = classpathResourcePath("graphql-mutation.properties");
+        HttpMutatorEngine engine;
+
+        PropertyManager.loadProperties(graphql);
+        engine = new HttpMutatorEngine();
+        JsonNode response = MAPPER.readTree(
+                "{\"Status Code\":200,"
+                        + "\"Headers\":{\"Content-Type\":\"application/json; charset=utf-8\"},"
+                        + "\"Body\":{\"id\":1,\"name\":\"book\"}}");
+        List<String> identifiers = new ArrayList<>();
+
+        engine.getAllMutants(response, group -> identifiers.add(group.getIdentifier()));
+
+        Assert.assertFalse(identifiers.contains("Status Code"));
+        Assert.assertTrue(identifiers.stream().anyMatch(id -> id.startsWith("Headers/")));
+        Assert.assertTrue(identifiers.stream().anyMatch(id -> id.startsWith("Body")));
+    }
+
+    @Test
+    public void httpMutatorDefaultConstructorUsesDefaultSeed() throws Exception {
+        HttpMutator mutator = new HttpMutator();
+
+        Assert.assertEquals(42L, mutator.getRandomSeed());
+        Assert.assertEquals(42L, RandomUtils.getSeed());
+        mutator.close();
+    }
+
+    @Test
+    public void httpMutatorPropertiesConstructorUsesDefaultSeed() throws Exception {
+        Path graphql = classpathResourcePath("graphql-mutation.properties");
+
+        HttpMutator mutator = new HttpMutator(graphql);
+
+        Assert.assertEquals(42L, mutator.getRandomSeed());
+        Assert.assertEquals(42L, RandomUtils.getSeed());
+        mutator.close();
+    }
+
+    @Test
+    public void httpMutatorSeedAndPropertiesConstructorInitializesBeforeEngine() throws Exception {
+        Path graphql = classpathResourcePath("graphql-mutation.properties");
+        HttpMutator mutator = new HttpMutator(777L, graphql);
+        JsonNode response = MAPPER.readTree(
+                "{\"Status Code\":200,"
+                        + "\"Headers\":{\"Content-Type\":\"application/json; charset=utf-8\"},"
+                        + "\"Body\":{\"id\":1,\"name\":\"book\"}}");
+        List<JsonNode> mutants;
+
+        mutator.withMutationStrategy(new es.us.isa.httpmutator.core.strategy.AllOperatorsStrategy());
+        mutants = mutator.mutate(response, "graphql");
+
+        Assert.assertEquals(777L, mutator.getRandomSeed());
+        Assert.assertEquals(777L, RandomUtils.getSeed());
+        Assert.assertTrue(mutants.stream().noneMatch(node -> node.path("Status Code").asInt() != 200));
+        Assert.assertTrue(mutants.stream().anyMatch(node -> node.path("Headers").toString()
+                .contains("Content-Type")));
+        mutator.close();
+    }
+
+    private static Properties loadClasspathProperties(String resourceName) throws Exception {
+        Properties properties = new Properties();
+        try (InputStream input = PropertyManager.class.getClassLoader().getResourceAsStream(resourceName)) {
+            Assert.assertNotNull("Missing classpath resource " + resourceName, input);
+            properties.load(input);
+        }
+        return properties;
+    }
+
+    private static Path classpathResourcePath(String resourceName) throws Exception {
+        return java.nio.file.Paths.get(PropertyManager.class.getClassLoader()
+                .getResource(resourceName)
+                .toURI());
+    }
+
+    private static Set<String> operatorEnabledKeys(Properties properties) {
+        Set<String> keys = new TreeSet<>();
+        for (String key : properties.stringPropertyNames()) {
+            if (key.startsWith("operator.") && key.endsWith(".enabled") && key.split("\\.").length > 3) {
+                keys.add(key);
+            }
+        }
+        return keys;
+    }
+}

--- a/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/body/BodyMutatorTest.java
+++ b/httpmutator-core/src/test/java/es/us/isa/httpmutator/core/body/BodyMutatorTest.java
@@ -295,23 +295,6 @@ public class BodyMutatorTest {
     }
 
     @Test
-    public void getAllMutants() {
-        activateAllMutators();
-        List<Mutant> mutants = jsonMutator.getAllMutants(jsonNode);
-        assertMutantCount("getAllMutants(JsonNode)", 192, mutants);
-    }
-
-    @Test
-    public void getAllMutantsAsString() {
-        activateAllMutators();
-        List<String> mutants = jsonMutator.getAllMutants(jsonString);
-        if (mutants.size() != 192) {
-            printStringMutantDiagnostics("getAllMutants(String)", 192, mutants.size());
-        }
-        assertEquals("The number of generated mutants does not match", 192, mutants.size());
-    }
-
-    @Test
     public void getAllMutantsProbZero() {
         activateAllMutators();
         List<Mutant> mutants = jsonMutator.getAllMutants(jsonNode, 0);
@@ -343,53 +326,5 @@ public class BodyMutatorTest {
         jsonMutator.setProperty("operator.value.null.enabled", "true");
         jsonMutator.setProperty("operator.object.enabled", "true");
         jsonMutator.setProperty("operator.array.enabled", "true");
-    }
-
-    private void assertMutantCount(String label, int expected, List<Mutant> mutants) {
-        if (mutants.size() != expected) {
-            printMutantDiagnostics(label, expected, mutants.size(), mutants);
-        }
-        assertEquals("The number of generated mutants does not match", expected, mutants.size());
-    }
-
-    private void printStringMutantDiagnostics(String label, int expected, int actual) {
-        System.err.println();
-        System.err.println("==== BodyMutatorTest mutation count mismatch ====");
-        System.err.println("Test: " + label);
-        System.err.println("Expected mutants: " + expected);
-        System.err.println("Actual mutants: " + actual);
-        System.err.println("The String API returns only mutated JSON strings, so this diagnostic run uses the path-based API");
-        System.err.println("to print the field, mutator, and operator for each generated mutation.");
-
-        final int[] index = {1};
-        jsonMutator.getAllMutants(jsonString, 1, group -> {
-            for (Mutant mutant : group.getMutants()) {
-                printMutant(index[0]++, mutant);
-            }
-        });
-        System.err.println("==== End BodyMutatorTest mutation diagnostics ====");
-        System.err.println();
-    }
-
-    private void printMutantDiagnostics(String label, int expected, int actual, List<Mutant> mutants) {
-        System.err.println();
-        System.err.println("==== BodyMutatorTest mutation count mismatch ====");
-        System.err.println("Test: " + label);
-        System.err.println("Expected mutants: " + expected);
-        System.err.println("Actual mutants: " + actual);
-        for (int i = 0; i < mutants.size(); i++) {
-            printMutant(i + 1, mutants.get(i));
-        }
-        System.err.println("==== End BodyMutatorTest mutation diagnostics ====");
-        System.err.println();
-    }
-
-    private void printMutant(int index, Mutant mutant) {
-        System.err.println(String.format(
-                "%03d field=%s mutator=%s operator=%s",
-                index,
-                mutant.getOriginalJsonPath(),
-                mutant.getMutatorClassName(),
-                mutant.getOperatorClassName()));
     }
 }

--- a/httpmutator-integrations/src/main/java/es/us/isa/httpmutator/integrations/restassured/HttpMutatorRestAssuredFilter.java
+++ b/httpmutator-integrations/src/main/java/es/us/isa/httpmutator/integrations/restassured/HttpMutatorRestAssuredFilter.java
@@ -7,6 +7,7 @@ import es.us.isa.httpmutator.core.reporter.CsvReporter;
 import es.us.isa.httpmutator.core.strategy.AllOperatorsStrategy;
 import es.us.isa.httpmutator.core.strategy.MutationStrategy;
 import es.us.isa.httpmutator.core.util.RandomUtils;
+import es.us.isa.httpmutator.integrations.restassured.RestAssuredMutantAssertionCsvReporter.Outcome;
 import io.restassured.filter.Filter;
 import io.restassured.filter.FilterContext;
 import io.restassured.response.Response;
@@ -45,6 +46,7 @@ public class HttpMutatorRestAssuredFilter implements Filter {
     private final HttpMutator httpMutator;
     private final Path reportDir;
     private final MutationSummaryCsvReporter reporter;
+    private final RestAssuredMutantAssertionCsvReporter perMutantReporter;
 
     private static final Logger log = LogManager.getLogger(HttpMutatorRestAssuredFilter.class);
 
@@ -90,6 +92,7 @@ public class HttpMutatorRestAssuredFilter implements Filter {
 
         this.httpMutator = new HttpMutator(randomSeed).withMutationStrategy(mutationStrategy).addReporter(new CsvReporter(reportDir.resolve(reportName + ".csv")));
         this.reporter = new MutationSummaryCsvReporter(reportDir.resolve(reportName + "-assert-summary.csv"));
+        this.perMutantReporter = new RestAssuredMutantAssertionCsvReporter(reportDir.resolve(reportName + "-per-mutant-assertions.csv"));
         this.originalAssertionFailurePolicy = originalAssertionFailurePolicy;
     }
 
@@ -550,6 +553,7 @@ public class HttpMutatorRestAssuredFilter implements Filter {
         MutationSummary summary =  new MutationSummary(perRequestResults, totalObserved, totalWithAssertions, discardedNoAssertions, discardedOriginalAssertionFailed, mutationExecuted, totalMutantsOverall, killedMutantsOverall);
         try {
             reporter.write(summary);
+            perMutantReporter.write();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -632,28 +636,33 @@ public class HttpMutatorRestAssuredFilter implements Filter {
         final StandardHttpResponse std = interaction.getOriginalStandardResponse();
         final Consumer<ValidatableResponse> assertFunc = interaction.getAssertions();
 
+        final AtomicInteger mutantIndex = new AtomicInteger();
         final AtomicInteger total = new AtomicInteger();
         final AtomicInteger killed = new AtomicInteger();
 
         // Delegate to HttpMutator: it will provide a MutantGroup to inspect
-        httpMutator.mutate(std, interaction.label, mutated -> {
+        httpMutator.mutate(std, interaction.label, (mutated, mutant) -> {
+            int index = mutantIndex.incrementAndGet();
             try {
                 // Convert mutated response back to a RestAssured Response
                 Response raResp = RestAssuredBidirectionalConverter.INSTANCE.fromStandardResponse(mutated);
                 ValidatableResponse valMResp = raResp.then();
 
                 total.incrementAndGet();
-                log.debug("Applying assertions to mutant for request Id = {}, mutant #{}.", interaction.getLabel(), total.get());
+                log.debug("Applying assertions to mutant for request Id = {}, mutant #{}.", interaction.getLabel(), index);
 
                 try {
                     // Apply user assertions; if they fail, we consider the mutant "killed"
                     assertFunc.accept(valMResp);
+                    perMutantReporter.record(interaction.getLabel(), index, mutant, false, Outcome.SURVIVED, "");
                 } catch (AssertionError | Exception e) {
                     killed.incrementAndGet();
+                    perMutantReporter.record(interaction.getLabel(), index, mutant, true, Outcome.KILLED, exceptionMessage(e));
                 }
             } catch (ConversionException e) {
                 // If conversion fails, skip this mutant but continue processing others
                 // (we do not increment 'total' in this case).
+                perMutantReporter.record(interaction.getLabel(), index, mutant, false, Outcome.CONVERSION_FAILED, exceptionMessage(e));
             }
         });
 
@@ -665,5 +674,16 @@ public class HttpMutatorRestAssuredFilter implements Filter {
         interaction.setMessage("Mutation executed on " + totalMutants + " mutants; killed " + killedMutants + ".");
 
         return new RequestMutationResult(interaction.getLabel(), RequestStatus.MUTATION_EXECUTED, interaction.getMessage(), totalMutants, killedMutants);
+    }
+
+    private static String exceptionMessage(Throwable e) {
+        if (e == null) {
+            return "";
+        }
+        String message = e.getMessage();
+        if (message == null || message.isEmpty()) {
+            return e.getClass().getSimpleName();
+        }
+        return message;
     }
 }

--- a/httpmutator-integrations/src/main/java/es/us/isa/httpmutator/integrations/restassured/RestAssuredMutantAssertionCsvReporter.java
+++ b/httpmutator-integrations/src/main/java/es/us/isa/httpmutator/integrations/restassured/RestAssuredMutantAssertionCsvReporter.java
@@ -1,0 +1,151 @@
+package es.us.isa.httpmutator.integrations.restassured;
+
+import es.us.isa.httpmutator.core.model.Mutant;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Writes one REST Assured assertion outcome row per mutant.
+ */
+public class RestAssuredMutantAssertionCsvReporter {
+
+    public enum Outcome {
+        SURVIVED,
+        KILLED,
+        CONVERSION_FAILED
+    }
+
+    public static final class Result {
+        private final String requestId;
+        private final int mutantIndex;
+        private final String mutator;
+        private final String operator;
+        private final String originalJsonPath;
+        private final boolean killed;
+        private final Outcome outcome;
+        private final String message;
+
+        public Result(String requestId,
+                      int mutantIndex,
+                      String mutator,
+                      String operator,
+                      String originalJsonPath,
+                      boolean killed,
+                      Outcome outcome,
+                      String message) {
+            this.requestId = requestId;
+            this.mutantIndex = mutantIndex;
+            this.mutator = mutator;
+            this.operator = operator;
+            this.originalJsonPath = originalJsonPath;
+            this.killed = killed;
+            this.outcome = outcome;
+            this.message = sanitizeMessage(message);
+        }
+
+        public String getRequestId() {
+            return requestId;
+        }
+
+        public int getMutantIndex() {
+            return mutantIndex;
+        }
+
+        public String getMutator() {
+            return mutator;
+        }
+
+        public String getOperator() {
+            return operator;
+        }
+
+        public String getOriginalJsonPath() {
+            return originalJsonPath;
+        }
+
+        public boolean isKilled() {
+            return killed;
+        }
+
+        public Outcome getOutcome() {
+            return outcome;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    private final Path csvPath;
+    private final List<Result> results = new ArrayList<Result>();
+
+    public RestAssuredMutantAssertionCsvReporter(Path csvPath) {
+        this.csvPath = csvPath;
+    }
+
+    public void record(String requestId,
+                       int mutantIndex,
+                       Mutant mutant,
+                       boolean killed,
+                       Outcome outcome,
+                       String message) {
+        String mutator = mutant == null ? "" : mutant.getMutatorClassName();
+        String operator = mutant == null ? "" : mutant.getOperatorClassName();
+        String originalJsonPath = mutant == null ? "" : mutant.getOriginalJsonPath();
+        record(new Result(requestId, mutantIndex, mutator, operator, originalJsonPath, killed, outcome, message));
+    }
+
+    public void record(Result result) {
+        if (result == null) {
+            throw new IllegalArgumentException("result must not be null");
+        }
+        results.add(result);
+    }
+
+    public void write() throws IOException {
+        Path parent = csvPath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(csvPath, StandardCharsets.UTF_8)) {
+            writer.write("requestId,mutantIndex,mutator,operator,originalJsonPath,killed,outcome,message");
+            writer.newLine();
+
+            for (Result result : results) {
+                writer.write(String.join(",",
+                        csv(result.getRequestId()),
+                        String.valueOf(result.getMutantIndex()),
+                        csv(result.getMutator()),
+                        csv(result.getOperator()),
+                        csv(result.getOriginalJsonPath()),
+                        String.valueOf(result.isKilled()),
+                        csv(result.getOutcome() == null ? "" : result.getOutcome().name()),
+                        csv(result.getMessage())
+                ));
+                writer.newLine();
+            }
+        }
+    }
+
+    private static String sanitizeMessage(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace('\r', ' ').replace('\n', ' ');
+    }
+
+    private static String csv(String value) {
+        if (value == null) {
+            return "\"\"";
+        }
+        String escaped = value.replace("\"", "\"\"");
+        return "\"" + escaped + "\"";
+    }
+}

--- a/httpmutator-integrations/src/test/java/es/us/isa/httpmutator/integrations/restassured/RestAssuredPerMutantAssertionReporterTest.java
+++ b/httpmutator-integrations/src/test/java/es/us/isa/httpmutator/integrations/restassured/RestAssuredPerMutantAssertionReporterTest.java
@@ -1,0 +1,149 @@
+package es.us.isa.httpmutator.integrations.restassured;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import es.us.isa.httpmutator.core.strategy.AllOperatorsStrategy;
+import es.us.isa.httpmutator.integrations.restassured.HttpMutatorRestAssuredFilter.MutationSummary;
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RestAssuredPerMutantAssertionReporterTest {
+
+    private WireMockServer wireMockServer;
+
+    @AfterEach
+    void tearDown() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+        RestAssured.reset();
+    }
+
+    @Test
+    void writesPerMutantAssertionCsvConsistentWithSummary() throws Exception {
+        Path reportDir = Paths.get("target", "httpmutator-restassured-test", "per-mutant");
+        String reportName = "per-mutant-report-test";
+        Path perMutantCsv = reportDir.resolve(reportName + "-per-mutant-assertions.csv");
+        Files.createDirectories(reportDir);
+        Files.deleteIfExists(perMutantCsv);
+
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        wireMockServer.stubFor(
+                get(urlEqualTo("/item"))
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"id\":7,\"name\":\"alpha\",\"ok\":true}")));
+
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = wireMockServer.port();
+
+        HttpMutatorRestAssuredFilter filter = new HttpMutatorRestAssuredFilter(
+                42L,
+                new AllOperatorsStrategy(),
+                reportDir,
+                reportName,
+                HttpMutatorRestAssuredFilter.OriginalAssertionFailurePolicy.THROW);
+        RestAssured.filters(filter);
+
+        given().when().get("/item").then().statusCode(200);
+        filter.addAssertionsForLastRequest((ValidatableResponse resp) -> {
+            resp.statusCode(200);
+            resp.body("id", equalTo(7));
+        });
+
+        MutationSummary summary = filter.runAllMutations();
+
+        assertTrue(Files.exists(perMutantCsv), "Per-mutant assertion CSV should be written");
+
+        List<String> lines = Files.readAllLines(perMutantCsv);
+        assertFalse(lines.isEmpty(), "CSV should include a header");
+        assertEquals("requestId,mutantIndex,mutator,operator,originalJsonPath,killed,outcome,message",
+                lines.get(0));
+
+        List<List<String>> rows = parseCsvRows(lines.subList(1, lines.size()));
+        long killedRows = 0;
+        long countedRows = 0;
+        String requestId = summary.getPerRequestResults().get(0).getLabel();
+
+        for (List<String> row : rows) {
+            assertEquals(8, row.size(), "Each per-mutant row should have 8 columns");
+            assertEquals(requestId, row.get(0), "Request id should match summary label");
+            assertFalse(row.get(1).trim().isEmpty(), "mutantIndex should be present");
+            assertFalse(row.get(3).trim().isEmpty(), "operator should be present");
+            assertFalse(row.get(6).trim().isEmpty(), "outcome should be present");
+
+            String outcome = row.get(6);
+            if ("KILLED".equals(outcome)) {
+                killedRows++;
+                countedRows++;
+                assertEquals("true", row.get(5));
+            } else if ("SURVIVED".equals(outcome)) {
+                countedRows++;
+                assertEquals("false", row.get(5));
+            } else {
+                assertEquals("CONVERSION_FAILED", outcome);
+            }
+        }
+
+        assertNotNull(summary);
+        assertEquals(summary.getKilledMutants(), killedRows,
+                "KILLED rows should match summary killed mutant count");
+        assertEquals(summary.getTotalMutants(), countedRows,
+                "KILLED + SURVIVED rows should match summary total mutant count");
+    }
+
+    private static List<List<String>> parseCsvRows(List<String> lines) {
+        List<List<String>> rows = new ArrayList<List<String>>();
+        for (String line : lines) {
+            if (line == null || line.isEmpty()) {
+                continue;
+            }
+            rows.add(parseCsvLine(line));
+        }
+        return rows;
+    }
+
+    private static List<String> parseCsvLine(String line) {
+        List<String> cells = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (c == '"') {
+                if (inQuotes && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                    current.append('"');
+                    i++;
+                } else {
+                    inQuotes = !inQuotes;
+                }
+            } else if (c == ',' && !inQuotes) {
+                cells.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        cells.add(current.toString());
+        return cells;
+    }
+}


### PR DESCRIPTION
This PR extends HttpMutator with more flexible configuration and more detailed mutation reporting.

### Changes

- Add a per-mutant metadata callback API for associating each mutated response with its corresponding mutation metadata.
- Add per-mutant REST Assured assertion reporting, including killed and surviving mutant outcomes in CSV format.
- Add configurable operator profiles:
  - `http-mutation.properties` for default behavior
  - `rest-mutation.properties` with all supported operators enabled
  - `graphql-mutation.properties` with HTTP status-code mutations disabled
- Support loading property overrides through the Java API and CLI.
- Add `mutation.body.ignore.paths` to exclude selected JSON paths and their descendants from body mutation.
- Normalize ignored paths such as `Body/user`, `/user`, and `user` to the same mutation path.
- Update the README and documentation for configuration, CLI usage, mutation operators, and extension APIs.
- Add unit and integration coverage for the new configuration, path exclusion, metadata, and reporting behavior.
